### PR TITLE
Rename ReactiveOps to Fairwinds

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 ReactiveOps
+   Copyright 2018 FairwindsOps Inc
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -1,4 +1,4 @@
-// Copyright 2019 ReactiveOps
+// Copyright 2019 FairwindsOps Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/dashboard/helpers.go
+++ b/pkg/dashboard/helpers.go
@@ -1,4 +1,4 @@
-// Copyright 2019 ReactiveOps
+// Copyright 2019 FairwindsOps Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -1,4 +1,4 @@
-// Copyright 2019 ReactiveOps
+// Copyright 2019 FairwindsOps Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Remaining mentions: 
```
./deploy/build.config:EXTERNAL_REGISTRY_BASE_DOMAIN=quay.io/reactiveops
./hack/manifests/dashboard/deployment.yaml:          image: "quay.io/reactiveops/goldilocks:master"
./hack/manifests/controller/deployment.yaml:          image: "quay.io/reactiveops/goldilocks:master"
./.circleci/config.yml:          username: reactiveops+circleci
```