### PR TITLE
Add exclude-containers filter option to dashboard

### DIFF
--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -31,6 +31,7 @@ func init() {
 	rootCmd.AddCommand(dashboardCmd)
 	dashboardCmd.PersistentFlags().IntVarP(&serverPort, "port", "p", 8080, "The port to serve the dashboard on.")
 	dashboardCmd.PersistentFlags().StringVar(&basePath, "base-path", "/", "Path on which the dashboard is served")
+	dashboardCmd.PersistentFlags().StringVarP(&excludeContainers, "exclude-containers", "e", "", "Comma delimited list of containers to exclude from recommendations.")
 }
 
 var dashboardCmd = &cobra.Command{
@@ -39,7 +40,7 @@ var dashboardCmd = &cobra.Command{
 	Long:  `Run the goldilocks dashboard that will show recommendations.`,
 	Run: func(cmd *cobra.Command, args []string) {
 
-		router := dashboard.GetRouter(serverPort, basePath, vpaLabels)
+		router := dashboard.GetRouter(serverPort, basePath, vpaLabels, excludeContainers)
 		http.Handle("/", router)
 		klog.Infof("Starting goldilocks dashboard server on port %d", serverPort)
 		klog.Fatalf("%v", http.ListenAndServe(fmt.Sprintf(":%d", serverPort), nil))

--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -125,7 +125,7 @@ func writeTemplate(tmpl *template.Template, data *templateData, w http.ResponseW
 }
 
 // GetRouter returns a mux router serving all routes necessary for the dashboard
-func GetRouter(port int, basePath string, vpaLabels map[string]string) *mux.Router {
+func GetRouter(port int, basePath string, vpaLabels map[string]string, excludeContainers string) *mux.Router {
 	router := mux.NewRouter()
 	router.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte("OK"))
@@ -148,7 +148,7 @@ func GetRouter(port int, basePath string, vpaLabels map[string]string) *mux.Rout
 			return
 		}
 
-		data, err := summary.Run(vpaLabels, "")
+		data, err := summary.Run(vpaLabels, excludeContainers)
 		if err != nil {
 			klog.Errorf("Error getting data: %v", err)
 			http.Error(w, "Error running summary.", 500)
@@ -183,8 +183,8 @@ func MainHandler(w http.ResponseWriter, r *http.Request, vpaData summary.Summary
 }
 
 // JSONHandler gets template data and renders json with it.
-func JSONHandler(w http.ResponseWriter, r *http.Request, vpaLabels map[string]string) {
-	data, err := summary.Run(vpaLabels, "")
+func JSONHandler(w http.ResponseWriter, r *http.Request, vpaLabels map[string]string, excludeContainers string) {
+	data, err := summary.Run(vpaLabels, excludeContainers)
 	if err != nil {
 		http.Error(w, "Error Fetching Summary", http.StatusInternalServerError)
 		return


### PR DESCRIPTION
Add `exclude-containers` argument to dashboard command to filter out containers.