### PR TITLE
Don't use deployment to lookup namespace, use the event instead

### DIFF
--- a/pkg/handler/deployment.go
+++ b/pkg/handler/deployment.go
@@ -28,7 +28,7 @@ import (
 
 // OnDeploymentChanged is a handler that should be called when a deployment chanages.
 func OnDeploymentChanged(deployment *appsv1.Deployment, event utils.Event) {
-	namespace, _ := getNamespaceForDeployment(deployment)
+	namespace, _ := getNamespaceFromName(event.Namespace)
 	switch strings.ToLower(event.EventType) {
 	case "delete":
 		klog.V(3).Infof("Deployment %s deleted. Deleting the VPA for it if it had one.", deployment.ObjectMeta.Name)
@@ -41,8 +41,7 @@ func OnDeploymentChanged(deployment *appsv1.Deployment, event utils.Event) {
 	}
 }
 
-func getNamespaceForDeployment(deployment *appsv1.Deployment) (*corev1.Namespace, error) {
-	nsName := deployment.ObjectMeta.Namespace
+func getNamespaceFromName(nsName string) (*corev1.Namespace, error) {
 	namespace := kube.GetNamespace(nsName)
 	return namespace, nil
 }


### PR DESCRIPTION
I modified the deployments handler to get the namespace object from the name of the namespace which I pull from the event rather than the deployment object.  This will prevent the lookup from failing when deployments are deleted.

Fixes #49. 