### PR TITLE
Mg/test run func

### DIFF
--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/klog"
 
+	"github.com/fairwindsops/goldilocks/pkg/kube"
 	"github.com/fairwindsops/goldilocks/pkg/summary"
 	"github.com/fairwindsops/goldilocks/pkg/utils"
 )
@@ -40,8 +41,9 @@ var summaryCmd = &cobra.Command{
 	Short: "Genarate a summary of the vpa recommendations in a namespace.",
 	Long:  `Gather all the vpa data in a namespace and generaate a summary of the recommendations.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		kubeClientVPA := kube.GetVPAInstance()
 
-		data, _ := summary.Run(utils.VpaLabels, excludeContainers)
+		data, _ := summary.Run(kubeClientVPA, utils.VpaLabels, excludeContainers)
 		summaryJSON, err := json.Marshal(data)
 		if err != nil {
 			klog.Fatalf("Error marshalling JSON: %v", err)

--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gorilla/mux"
 	"k8s.io/klog"
 
+	"github.com/fairwindsops/goldilocks/pkg/kube"
 	"github.com/fairwindsops/goldilocks/pkg/summary"
 )
 
@@ -162,7 +163,9 @@ func GetRouter(port int, basePath string, vpaLabels map[string]string, excludeCo
 			return
 		}
 
-		data, err := summary.Run(vpaLabels, excludeContainers)
+		kubeClientVPA := kube.GetVPAInstance()
+
+		data, err := summary.Run(kubeClientVPA, vpaLabels, excludeContainers)
 		if err != nil {
 			klog.Errorf("Error getting data: %v", err)
 			http.Error(w, "Error running summary.", 500)

--- a/pkg/summary/summary.go
+++ b/pkg/summary/summary.go
@@ -50,10 +50,8 @@ type Summary struct {
 }
 
 // Run creates a summary of the vpa info for all namespaces.
-func Run(vpaLabels map[string]string, excludeContainers string) (Summary, error) {
+func Run(kubeClientVPA *kube.VPAClientInstance, vpaLabels map[string]string, excludeContainers string) (Summary, error) {
 	klog.V(3).Infof("Looking for VPAs with labels: %v", vpaLabels)
-
-	kubeClientVPA := kube.GetVPAInstance()
 
 	vpaListOptions := metav1.ListOptions{
 		LabelSelector: labels.Set(vpaLabels).String(),

--- a/pkg/summary/summary_test.go
+++ b/pkg/summary/summary_test.go
@@ -1,0 +1,94 @@
+// Copyright 2019 FairwindsOps Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package summary
+
+import (
+	"testing"
+
+	"github.com/fairwindsops/goldilocks/pkg/kube"
+	"github.com/fairwindsops/goldilocks/pkg/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRun(t *testing.T) {
+	kubeClientVPA := kube.GetMockVPAClient()
+
+	var summary Summary
+
+	got, err := Run(kubeClientVPA, utils.VpaLabels, "true")
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, got, summary)
+}
+
+// func TestRunSummary(t *testing.T) {
+// constructSummary should be refactored to pass a client in.
+// This test is commented out for now and
+// Will be refactored/renamed after
+// Some work is done on refactoring functions for better scope
+// 	kubeClientVPA := kube.GetMockVPAClient()
+
+// 	updateMode := v1beta2.UpdateModeOff
+// 	var testVPA = &v1beta2.VerticalPodAutoscaler{
+// 		ObjectMeta: metav1.ObjectMeta{
+// 			Name:      "test-vpa",
+// 			Labels:    utils.VpaLabels,
+// 			Namespace: "testing",
+// 		},
+// 		Spec: v1beta2.VerticalPodAutoscalerSpec{
+// 			TargetRef: &autoscaling.CrossVersionObjectReference{
+// 				APIVersion: "extensions/v1beta1",
+// 				Kind:       "Deployment",
+// 				Name:       "test-vpa",
+// 			},
+// 			UpdatePolicy: &v1beta2.PodUpdatePolicy{
+// 				UpdateMode: &updateMode,
+// 			},
+// 		},
+// 	}
+// 	var testVPANoLabels = &v1beta2.VerticalPodAutoscaler{
+// 		ObjectMeta: metav1.ObjectMeta{
+// 			Name:      "test-vpa",
+// 			Namespace: "testing",
+// 		},
+// 		Spec: v1beta2.VerticalPodAutoscalerSpec{
+// 			TargetRef: &autoscaling.CrossVersionObjectReference{
+// 				APIVersion: "extensions/v1beta1",
+// 				Kind:       "Deployment",
+// 				Name:       "test-vpa",
+// 			},
+// 			UpdatePolicy: &v1beta2.PodUpdatePolicy{
+// 				UpdateMode: &updateMode,
+// 			},
+// 		},
+// 	}
+
+// 	_, errOk := kubeClientVPA.Client.AutoscalingV1beta2().VerticalPodAutoscalers("testing").Create(testVPA)
+// 	assert.NoError(t, errOk)
+
+// 	_, errOk2 := kubeClientVPA.Client.AutoscalingV1beta2().VerticalPodAutoscalers("testing").Create(testVPANoLabels)
+// 	assert.NoError(t, errOk2)
+
+// 	var summary = Summary{
+// 		Namespaces: []string{
+// 			"testing",
+// 		},
+// 	}
+
+// 	got, err := Run(kubeClientVPA, utils.VpaLabels, "true")
+// 	assert.NoError(t, err)
+
+// 	assert.EqualValues(t, summary, got)
+// }


### PR DESCRIPTION
- Adds test for Run func
- Refactors Run func to pass in a `*kube.VPAClientInstance` instead of creating one inside the function
- Additional commented out test that will be in use after refactoring funcs in summary.go