### PR TITLE
Fix use of labels for update mode

### DIFF
--- a/pkg/vpa/vpa.go
+++ b/pkg/vpa/vpa.go
@@ -195,7 +195,7 @@ func (r Reconciler) reconcileDeploymentsAndVPAs(ns *corev1.Namespace, vpas []vpa
 }
 
 func (r Reconciler) reconcileDeploymentAndVPA(ns *corev1.Namespace, deployment appsv1.Deployment, vpa *vpav1.VerticalPodAutoscaler, vpaUpdateMode *vpav1.UpdateMode) error {
-	desiredVPA := r.getVPAObject(vpa, ns, deployment.Name)
+	desiredVPA := r.getVPAObject(vpa, ns, deployment.Name, vpaUpdateMode)
 
 	if vpaUpdateModeOverride, explicit := vpaUpdateModeForResource(&deployment); explicit {
 		vpaUpdateMode = vpaUpdateModeOverride
@@ -308,7 +308,7 @@ func (r Reconciler) updateVPA(vpa vpav1.VerticalPodAutoscaler) error {
 	return nil
 }
 
-func (r Reconciler) getVPAObject(existingVPA *vpav1.VerticalPodAutoscaler, ns *corev1.Namespace, vpaName string) vpav1.VerticalPodAutoscaler {
+func (r Reconciler) getVPAObject(existingVPA *vpav1.VerticalPodAutoscaler, ns *corev1.Namespace, vpaName string, updateMode *vpav1.UpdateMode) vpav1.VerticalPodAutoscaler {
 	var desiredVPA vpav1.VerticalPodAutoscaler
 
 	// create a brand new vpa with the correct information

--- a/pkg/vpa/vpa.go
+++ b/pkg/vpa/vpa.go
@@ -197,8 +197,7 @@ func (r Reconciler) reconcileDeploymentsAndVPAs(ns *corev1.Namespace, vpas []vpa
 func (r Reconciler) reconcileDeploymentAndVPA(ns *corev1.Namespace, deployment appsv1.Deployment, vpa *vpav1.VerticalPodAutoscaler, vpaUpdateMode *vpav1.UpdateMode) error {
 	desiredVPA := r.getVPAObject(vpa, ns, deployment.Name)
 
-	vpaUpdateModeOverride, override := vpaUpdateModeForResource(&deployment)
-	if override {
+	if vpaUpdateModeOverride, explicit := vpaUpdateModeForResource(&deployment); explicit {
 		vpaUpdateMode = vpaUpdateModeOverride
 		klog.V(5).Infof("Deployment/%s has custom vpa-update-mode=%s", deployment.Name, vpaUpdateMode)
 	}
@@ -328,7 +327,6 @@ func (r Reconciler) getVPAObject(existingVPA *vpav1.VerticalPodAutoscaler, ns *c
 	// update the labels on the VPA
 	desiredVPA.Labels = utils.VPALabels
 
-	updateMode, _ := vpaUpdateModeForResource(ns)
 	// update the spec on the VPA
 	desiredVPA.Spec = vpav1.VerticalPodAutoscalerSpec{
 		TargetRef: &autoscaling.CrossVersionObjectReference{

--- a/pkg/vpa/vpa.go
+++ b/pkg/vpa/vpa.go
@@ -199,7 +199,7 @@ func (r Reconciler) reconcileDeploymentAndVPA(ns *corev1.Namespace, deployment a
 
 	if vpaUpdateModeOverride, explicit := vpaUpdateModeForResource(&deployment); explicit {
 		vpaUpdateMode = vpaUpdateModeOverride
-		klog.V(5).Infof("Deployment/%s has custom vpa-update-mode=%s", deployment.Name, vpaUpdateMode)
+		klog.V(5).Infof("Deployment/%s has custom vpa-update-mode=%s", deployment.Name, *vpaUpdateMode)
 	}
 	if vpa == nil {
 		klog.V(5).Infof("Deployment/%s does not have a VPA currently, creating VPA/%s", deployment.Name, deployment.Name)

--- a/pkg/vpa/vpa_test.go
+++ b/pkg/vpa/vpa_test.go
@@ -79,8 +79,9 @@ func Test_vpaUpdateModeForNamespace(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			want := test.updateMode
-			got := vpaUpdateModeForResource(test.ns)
+			got, explicit := vpaUpdateModeForResource(test.ns)
 			assert.Equal(t, want, *got)
+			assert.Equal(t, true, explicit)
 		})
 	}
 }
@@ -108,7 +109,8 @@ func Test_getVPAObject(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			vpa := rec.getVPAObject(test.vpa, test.ns, "test-vpa")
+			mode, _ := vpaUpdateModeForResource(test.ns)
+			vpa := rec.getVPAObject(test.vpa, test.ns, "test-vpa", mode)
 
 			// expected ObjectMeta
 			assert.Equal(t, "test-vpa", vpa.Name)
@@ -132,7 +134,8 @@ func Test_createVPA(t *testing.T) {
 	rec := GetInstance()
 	rec.DryRun = true
 
-	testVPA := rec.getVPAObject(nil, nsTesting, "test-vpa")
+	updateMode, _ := vpaUpdateModeForResource(nsTesting)
+	testVPA := rec.getVPAObject(nil, nsTesting, "test-vpa", updateMode)
 
 	err := rec.createVPA(testVPA)
 	assert.NoError(t, err)
@@ -155,7 +158,8 @@ func Test_deleteVPA(t *testing.T) {
 	rec := GetInstance()
 	rec.DryRun = true
 
-	testVPA := rec.getVPAObject(nil, nsTesting, "test-vpa")
+	updateMode, _ := vpaUpdateModeForResource(nsTesting)
+	testVPA := rec.getVPAObject(nil, nsTesting, "test-vpa", updateMode)
 	_, err := VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(nsTesting.Name).Create(context.TODO(), &testVPA, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
@@ -183,7 +187,8 @@ func Test_updateVPA(t *testing.T) {
 	testNS := nsTesting.DeepCopy()
 	testNS.Labels["goldilocks.fairwinds.com/vpa-update-mode"] = "off"
 
-	testVPA := rec.getVPAObject(nil, testNS, "test-vpa")
+	updateMode, _ := vpaUpdateModeForResource(testNS)
+	testVPA := rec.getVPAObject(nil, testNS, "test-vpa", updateMode)
 	_, err := VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(testNS.Name).Create(context.TODO(), &testVPA, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
@@ -203,7 +208,8 @@ func Test_updateVPA(t *testing.T) {
 
 	// change the update mode
 	testNS.Labels["goldilocks.fairwinds.com/vpa-update-mode"] = "auto"
-	newVPA := rec.getVPAObject(nil, testNS, "test-vpa")
+	updateMode, _ = vpaUpdateModeForResource(testNS)
+	newVPA := rec.getVPAObject(nil, testNS, "test-vpa", updateMode)
 
 	errUpdate2 := rec.updateVPA(newVPA)
 	assert.NoError(t, errUpdate2)
@@ -227,9 +233,11 @@ func Test_listVPA(t *testing.T) {
 	testNS2.Namespace = "ns2"
 
 	// test vpas
-	vpa1 := rec.getVPAObject(nil, testNS1, "test1")
-	vpa2 := rec.getVPAObject(nil, testNS1, "test2")
-	vpa3 := rec.getVPAObject(nil, testNS2, "test3")
+	updateMode1, _ := vpaUpdateModeForResource(testNS1)
+	updateMode2, _ := vpaUpdateModeForResource(testNS2)
+	vpa1 := rec.getVPAObject(nil, testNS1, "test1", updateMode1)
+	vpa2 := rec.getVPAObject(nil, testNS1, "test2", updateMode1)
+	vpa3 := rec.getVPAObject(nil, testNS2, "test3", updateMode2)
 
 	// create vpas
 	_ = rec.createVPA(vpa1)

--- a/pkg/vpa/vpa_test.go
+++ b/pkg/vpa/vpa_test.go
@@ -45,31 +45,37 @@ func Test_vpaUpdateModeForNamespace(t *testing.T) {
 	tests := []struct {
 		name       string
 		ns         *corev1.Namespace
+		explicit   bool
 		updateMode vpav1.UpdateMode
 	}{
 		{
 			name:       "unlabeled (default)",
 			ns:         nsNotLabeled,
+			explicit:   false,
 			updateMode: vpav1.UpdateModeOff,
 		},
 		{
 			name:       "labeled: enabled=false",
 			ns:         nsLabeledFalse,
+			explicit:   false,
 			updateMode: vpav1.UpdateModeOff,
 		},
 		{
 			name:       "labled: enabled=true",
 			ns:         nsLabeledTrue,
+			explicit:   false,
 			updateMode: vpav1.UpdateModeOff,
 		},
 		{
 			name:       "labled: enabled=true, vpa-update-mode=off",
 			ns:         nsLabeledTrueUpdateModeOff,
+			explicit:   true,
 			updateMode: vpav1.UpdateModeOff,
 		},
 		{
 			name:       "labled: enabled=true, vpa-update-mode=auto",
 			ns:         nsLabeledTrueUpdateModeAuto,
+			explicit:   true,
 			updateMode: vpav1.UpdateModeAuto,
 		},
 	}
@@ -81,7 +87,7 @@ func Test_vpaUpdateModeForNamespace(t *testing.T) {
 			want := test.updateMode
 			got, explicit := vpaUpdateModeForResource(test.ns)
 			assert.Equal(t, want, *got)
-			assert.Equal(t, true, explicit)
+			assert.Equal(t, test.explicit, explicit)
 		})
 	}
 }


### PR DESCRIPTION
This fixed a bug found by a user, who was trying to use a deployment's labels to set update mode.