### PR TITLE
Updates for 3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ references:
     command_runner_image: quay.io/reactiveops/ci-images:v11-stretch
     enable_docker_layer_caching: true
     store-test-results: /tmp/test-results
+    kind_version: 0.9.0
     requires:
       - build-container
     filters:
@@ -64,16 +65,20 @@ workflows:
             tags:
               ignore: /.*/
       - rok8s-scripts/kubernetes_e2e_tests:
-          name: "End-To-End Kubernetes 1.16.4"
-          kind_node_image: "kindest/node:v1.16.4@sha256:b91a2c2317a000f3a783489dfb755064177dbc3a0b2f4147d50f04825d016f55"
+          name: "End-To-End Kubernetes 1.16.15"
+          kind_node_image: "kindest/node:v1.16.15@sha256:a89c771f7de234e6547d43695c7ab047809ffc71a0c3b65aa54eda051c45ed20"
           <<: *e2e_configuration
       - rok8s-scripts/kubernetes_e2e_tests:
-          name: "End-To-End Kubernetes 1.17.0"
-          kind_node_image: "kindest/node:v1.17.0@sha256:9512edae126da271b66b990b6fff768fbb7cd786c7d39e86bdf55906352fdf62"
+          name: "End-To-End Kubernetes 1.17.11"
+          kind_node_image: "kindest/node:v1.17.11@sha256:5240a7a2c34bf241afb54ac05669f8a46661912eab05705d660971eeb12f6555"
           <<: *e2e_configuration
       - rok8s-scripts/kubernetes_e2e_tests:
-          name: End-To-End Kubernets 1.18.2
-          kind_node_image: "kindest/node:v1.18.2@sha256:7b27a6d0f2517ff88ba444025beae41491b016bc6af573ba467b70c5e8e0d85f"
+          name: "End-To-End Kubernetes 1.18.8"
+          kind_node_image: "kindest/node:v1.18.8@sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb"
+          <<: *e2e_configuration
+      - rok8s-scripts/kubernetes_e2e_tests:
+          name: "End-To-End Kubernetes 1.19.1"
+          kind_node_image: "kindest/node:v1.19.1@sha256:98cf5288864662e37115e362b23e4369c8c4a408f99cbc06e58ac30ddc721600"
           <<: *e2e_configuration
       - rok8s-scripts/docker_build_and_push:
           name: build-and-push-container

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,16 +64,16 @@ workflows:
             tags:
               ignore: /.*/
       - rok8s-scripts/kubernetes_e2e_tests:
-          name: "End-To-End Kubernetes 1.15.7"
-          kind_node_image: "kindest/node:v1.15.7@sha256:e2df133f80ef633c53c0200114fce2ed5e1f6947477dbc83261a6a921169488d"
-          <<: *e2e_configuration
-      - rok8s-scripts/kubernetes_e2e_tests:
           name: "End-To-End Kubernetes 1.16.4"
           kind_node_image: "kindest/node:v1.16.4@sha256:b91a2c2317a000f3a783489dfb755064177dbc3a0b2f4147d50f04825d016f55"
           <<: *e2e_configuration
       - rok8s-scripts/kubernetes_e2e_tests:
           name: "End-To-End Kubernetes 1.17.0"
           kind_node_image: "kindest/node:v1.17.0@sha256:9512edae126da271b66b990b6fff768fbb7cd786c7d39e86bdf55906352fdf62"
+          <<: *e2e_configuration
+      - rok8s-scripts/kubernetes_e2e_tests:
+          name: End-To-End Kubernets 1.18.2
+          kind_node_image: "kindest/node:v1.18.2@sha256:7b27a6d0f2517ff88ba444025beae41491b016bc6af573ba467b70c5e8e0d85f"
           <<: *e2e_configuration
       - rok8s-scripts/docker_build_and_push:
           name: build-and-push-container

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Once your VPAs are in place, you'll see recommendations appear in the Goldilocks
 There are multiple ways to install VPA for use with Goldilocks:
 
 * Install using the `hack/vpa-up.sh` script from the [vertical-pod-autoscaler repository](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler)
-* Set the value `installVPA=true` when doing the Helm chart installation of Goldilocks. This will run the script from VPA in your cluster.
+* Install using the [Fairwinds VPA Helm Chart](https://github.com/FairwindsOps/charts/tree/master/stable/vpa)
 
 #### Important Note about VPA
 
@@ -39,7 +39,7 @@ The full VPA install includes the updater and the admission webhook for VPA. Gol
 
 ### Prometheus (optional)
 
-[VPA](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) does not require the use of prometheus, but it is supported.
+[VPA](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) does not require the use of prometheus, but it is supported. The use of prometheus may provide more accurate results.
 
 ### GKE Notes
 

--- a/e2e/tests/00_setup.yaml
+++ b/e2e/tests/00_setup.yaml
@@ -10,14 +10,13 @@ testcases:
   - script: |
       helm repo add bitnami https://charts.bitnami.com/bitnami
       helm repo update
-      kubectl create namespace metrics-server
-      helm -n metrics-server upgrade --install metrics-server bitnami/metrics-server --set apiService.create=true --set extraArgs.kubelet-insecure-tls=true
+      helm -n metrics-server upgrade --install metrics-server bitnami/metrics-server --set apiService.create=true --set extraArgs.kubelet-insecure-tls=true --create-namespace
 - name: Install VPA Recommender
   steps:
   - script: |
-      kubectl apply -f https://raw.githubusercontent.com/kubernetes/autoscaler/{{.vpa-ref}}/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
-      kubectl apply -f https://raw.githubusercontent.com/kubernetes/autoscaler/{{.vpa-ref}}/vertical-pod-autoscaler/deploy/vpa-v1-crd.yaml
-      kubectl apply -f https://raw.githubusercontent.com/kubernetes/autoscaler/{{.vpa-ref}}/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
+      helm repo add fairwinds-stable https://charts.fairwinds.com/stable
+      helm repo update
+      helm install vpa fairwinds-stable/vpa --namespace vpa --create-namespace
   - script: kubectl get crd verticalpodautoscalers.autoscaling.k8s.io -oname
     retry: 6
     delay: 5

--- a/e2e/tests/99_cleanup.yaml
+++ b/e2e/tests/99_cleanup.yaml
@@ -1,18 +1,12 @@
 version: "2"
 name: Cleanup
-vars:
-  timeout: 60s
-  vpa-wait: 20
-  vpa-ref: e16a0adef6c7d79a23d57f9bbbef26fc9da59378
 testcases:
 - name: Cleanup
   steps:
   - script: |
       kubectl delete ns demo demo-no-label demo-included demo-excluded goldilocks
   - script: |
-      kubectl delete -f https://raw.githubusercontent.com/kubernetes/autoscaler/{{.vpa-ref}}/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
-      kubectl delete -f https://raw.githubusercontent.com/kubernetes/autoscaler/{{.vpa-ref}}/vertical-pod-autoscaler/deploy/vpa-beta2-crd.yaml
-      kubectl delete -f https://raw.githubusercontent.com/kubernetes/autoscaler/{{.vpa-ref}}/vertical-pod-autoscaler/deploy/vpa-rbac.yaml
-  - script: |
       helm -n metrics-server delete metrics-server
       kubectl delete ns metrics-server
+      helm -n vpa delete vpa
+      kubectl delete ns vpa

--- a/hack/kind/course.yml
+++ b/hack/kind/course.yml
@@ -23,8 +23,8 @@ charts:
       apiService:
         create: true
       extraArgs:
-        - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types=InternalIP
+        kubelet-insecure-tls: 1
+        kubelet-preferred-address-types: InternalIP
   vpa:
     namespace: vpa
     version: "0.1.0"

--- a/hack/kind/course.yml
+++ b/hack/kind/course.yml
@@ -12,16 +12,23 @@ repositories:
     url: https://charts.fairwinds.com/stable
   fairwinds-incubator:
     url: https://charts.fairwinds.com/incubator
+  bitnami:
+    url: https://charts.bitnami.com/bitnami
 charts:
   metrics-server:
     namespace: metrics-server
-    version: "2.8.2"
-    set-values:
-      args:
+    repository: bitnami
+    version: "4.3.1"
+    values:
+      apiService:
+        create: true
+      extraArgs:
         - --kubelet-insecure-tls
         - --kubelet-preferred-address-types=InternalIP
-        - --metric-resolution=30s
-        - --v=3
+  vpa:
+    namespace: vpa
+    version: "0.1.0"
+    repository: fairwinds-stable
   load-generator:
     namespace: demo
     version: 0.1.1

--- a/hack/kind/setup.sh
+++ b/hack/kind/setup.sh
@@ -4,8 +4,6 @@ set -e
 
 kind_required_version=0.8.1
 kind_node_image="kindest/node:v1.17.5@sha256:ab3f9e6ec5ad8840eeb1f76c89bb7948c77bbf76bcebe1a8b59790b8ae9a283a"
-vertical_pod_autoscaler_ref=e0f63c1caeec518f85c4347b673e4e99e4fb0059
-install_vpa=${1:-true}
 install_goldilocks=${2:-true}
 
 ## Test Infra Setup
@@ -41,21 +39,8 @@ until kubectl cluster-info; do
     sleep 3
 done
 
-if $install_vpa; then
-  ## Install VPA
-
-  if [ ! -d "autoscaler" ] ; then
-      git clone "https://github.com/kubernetes/autoscaler.git"
-  fi
-
-  cd autoscaler/vertical-pod-autoscaler
-  git checkout "$vertical_pod_autoscaler_ref"
-  ./hack/vpa-up.sh
-
-  cd ../../
-fi
-
 ## Reckoner
+## Installs all dependencies such as metrics-server and vpa
 
 reckoner plot course.yml -a
 

--- a/hack/kind/setup.sh
+++ b/hack/kind/setup.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-kind_required_version=0.8.1
-kind_node_image="kindest/node:v1.17.5@sha256:ab3f9e6ec5ad8840eeb1f76c89bb7948c77bbf76bcebe1a8b59790b8ae9a283a"
+kind_required_version=0.9.0
+kind_node_image="kindest/node:v1.18.8@sha256:f4bcc97a0ad6e7abaf3f643d890add7efe6ee4ab90baeb374b4f41a4c95567eb"
 install_goldilocks=${2:-true}
 
 ## Test Infra Setup

--- a/hack/manifests/controller/clusterrole.yaml
+++ b/hack/manifests/controller/clusterrole.yaml
@@ -32,3 +32,4 @@ rules:
       - 'list'
       - 'create'
       - 'delete'
+      - 'update'


### PR DESCRIPTION
* Change to use vpa chart for e2e tests
* Update documentation for installation of vpa
* Corresponding changes to Helm chart and docs associated
* e2e test updates to kind version and kube versions. Drop 1.15