### PR TITLE
fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 Goldilocks is a utility that can help you identify a starting point for resource requests and limits.
 
 # Documentation
-Check out the [documentation at docs.fairwinds.com](goldilocks.docs.fairwinds.com)
+Check out the [documentation at docs.fairwinds.com](https://goldilocks.docs.fairwinds.com/)
 
 ## How can this help with my resource settings?
 


### PR DESCRIPTION
At line 22, the link is missing `https://`, which redirects to an incorrect url (`https://github.com/FairwindsOps/goldilocks/blob/master/goldilocks.docs.fairwinds.com`).