### PR TITLE
Add a filter on recommendation

### DIFF
--- a/cmd/summary.go
+++ b/cmd/summary.go
@@ -30,12 +30,21 @@ import (
 var excludeContainers string
 var outputFile string
 var namespace string
+var filter string
+
+const filterHelpText = `Filter results by recommendation.
+all: with or without recommendation
+any: with any type of recommendation
+guaranteed: with guaranteed recommendation
+burstable: with burstable recommendation
+`
 
 func init() {
 	rootCmd.AddCommand(summaryCmd)
 	summaryCmd.PersistentFlags().StringVarP(&excludeContainers, "exclude-containers", "e", "", "Comma delimited list of containers to exclude from recommendations.")
 	summaryCmd.PersistentFlags().StringVarP(&outputFile, "output-file", "f", "", "File to write output from audit.")
 	summaryCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Limit the summary to only a single Namespace.")
+	summaryCmd.PersistentFlags().StringVar(&filter, "filter", "all", filterHelpText)
 }
 
 var summaryCmd = &cobra.Command{
@@ -46,6 +55,9 @@ By default the summary will be about all VPAs in all namespaces.`,
 	Args: cobra.ArbitraryArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		var opts []summary.Option
+
+		// apply recommendation filter (defaults to all)
+		opts = append(opts, summary.WithFilter(filter))
 
 		// limit to a single namespace
 		if namespace != "" {

--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -27,6 +27,7 @@ import (
 func Dashboard(opts Options) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
+		filter := r.URL.Query().Get("filter")
 
 		var namespace string
 		if val, ok := vars["namespace"]; ok {
@@ -38,6 +39,7 @@ func Dashboard(opts Options) http.Handler {
 			summary.ForNamespace(namespace),
 			summary.ForVPAsWithLabels(opts.vpaLabels),
 			summary.ExcludeContainers(opts.excludedContainers),
+			summary.WithFilter(filter),
 		)
 
 		vpaData, err := summarizer.GetSummary()
@@ -50,7 +52,8 @@ func Dashboard(opts Options) http.Handler {
 		tmpl, err := getTemplate("dashboard",
 			"container",
 			"dashboard",
-			"filter",
+			"filter_ns",
+			"filter_reco",
 			"namespace",
 		)
 		if err != nil {

--- a/pkg/dashboard/namespace-list.go
+++ b/pkg/dashboard/namespace-list.go
@@ -34,7 +34,7 @@ func NamespaceList(opts Options) http.Handler {
 		}
 
 		tmpl, err := getTemplate("namespace_list",
-			"filter",
+			"filter_ns",
 			"namespace_list",
 		)
 		if err != nil {

--- a/pkg/dashboard/templates.go
+++ b/pkg/dashboard/templates.go
@@ -16,13 +16,14 @@ var templateBox = (*packr.Box)(nil)
 
 // templates
 const (
-	ContainerTemplateName = "container.gohtml"
-	DashboardTemplateName = "dashboard.gohtml"
-	FilterTemplateName    = "filter.gohtml"
-	FooterTemplateName    = "footer.gohtml"
-	HeadTemplateName      = "head.gohtml"
-	NamespaceTemplateName = "namespace.gohtml"
-	NavbarTemplateName    = "navbar.gohtml"
+	ContainerTemplateName       = "container.gohtml"
+	DashboardTemplateName       = "dashboard.gohtml"
+	FilterNamespaceTemplateName = "filter_ns.gohtml"
+	FilterRecoTemplateName      = "filter_reco.gohtml"
+	FooterTemplateName          = "footer.gohtml"
+	HeadTemplateName            = "head.gohtml"
+	NamespaceTemplateName       = "namespace.gohtml"
+	NavbarTemplateName          = "navbar.gohtml"
 )
 
 var (

--- a/pkg/dashboard/templates/dashboard.gohtml
+++ b/pkg/dashboard/templates/dashboard.gohtml
@@ -32,8 +32,9 @@
     </nav>
 
     {{ if gt (len .Data.Namespaces) 1 }}
-      {{ template "filter" . }}
+      {{ template "filter_ns" . }}
     {{ end }}
+    {{ template "filter_reco" . }}
   </header>
 
   <div class="layoutSidebar__main">

--- a/pkg/dashboard/templates/filter_ns.gohtml
+++ b/pkg/dashboard/templates/filter_ns.gohtml
@@ -1,4 +1,4 @@
-{{define "filter"}}
+{{define "filter_ns"}}
 <form aria-controls="js-filter-container" id="js-filter-form" role="search">
     <label class="visually-hidden" for="namespace-filter-input">
         Filter namespaces

--- a/pkg/dashboard/templates/filter_reco.gohtml
+++ b/pkg/dashboard/templates/filter_reco.gohtml
@@ -1,0 +1,38 @@
+{{ define "selected-filter" }}
+  {{ if . }}
+    <i aria-hidden="true" class="fas fa-fw fa-check"></i>
+  {{ end }}
+{{ end }}
+
+{{ define "filter_reco" }}
+
+<div class="filters">
+  <span class="linkIcon"><i class="fas fa-fw fa-filter"></i> Filters:</span>
+  <ul role="list">
+    <li>
+      <a title="Show containers with or without recommendation" href="?filter=all">
+        All
+        {{ template "selected-filter" (eq .Data.Filter "all") }}
+      </a>
+    </li>
+    <li>
+      <a title="Show containers with a recommendation" href="?filter=any">
+        With Recommendation
+        {{ template "selected-filter" (eq .Data.Filter "any") }}
+      </a> 
+    </li>
+    <li>
+      <a title="Show containers with Guaranteed PoS recommendation, even if they match the Burstable" href="?filter=guaranteed">
+        With Guaranteed
+        {{ template "selected-filter" (eq .Data.Filter "guaranteed") }}
+      </a> 
+    </li>
+    <li>
+      <a title="Show containers with Burstable PoS recommendation, even if they match the Guaranteed" href="?filter=burstable">
+        With Burstable
+        {{ template "selected-filter" (eq .Data.Filter "burstable") }}
+      </a> 
+    </li>
+  </ul>
+</div>
+{{ end}}

--- a/pkg/dashboard/templates/namespace_list.gohtml
+++ b/pkg/dashboard/templates/namespace_list.gohtml
@@ -20,7 +20,7 @@
       </ul>
     </nav>
 
-      {{ template "filter" . }}
+      {{ template "filter_ns" . }}
     {{ end }}
   </header>
 

--- a/pkg/summary/options.go
+++ b/pkg/summary/options.go
@@ -15,6 +15,7 @@ type options struct {
 	namespace          string
 	vpaLabels          map[string]string
 	excludedContainers sets.String
+	filter             string
 }
 
 // defaultOptions for a Summarizer
@@ -25,6 +26,7 @@ func defaultOptions() *options {
 		namespace:          namespaceAllNamespaces,
 		vpaLabels:          utils.VPALabels,
 		excludedContainers: sets.NewString(),
+		filter:             "all",
 	}
 }
 
@@ -46,5 +48,16 @@ func ExcludeContainers(excludedContainers sets.String) Option {
 func ForVPAsWithLabels(vpaLabels map[string]string) Option {
 	return func(opts *options) {
 		opts.vpaLabels = vpaLabels
+	}
+}
+
+// WithFilter is an Option for limiting the summary to VPAs with unmet recommendations
+func WithFilter(filter string) Option {
+	return func(opts *options) {
+		if filter == "" {
+			opts.filter = "all"
+		} else {
+			opts.filter = filter
+		}
 	}
 }


### PR DESCRIPTION
As suggested in #321, this PR adds a filter to hide containers that matches the VPA recommendation.


The proposed filters are:
- all: current behaviour
- any: show containers that don't meet recommendations
- guaranteed: show containers that don't meet guaranteed recommendations
- burstable: show containers that don't meet burstable recommendations



UI:

![image](https://user-images.githubusercontent.com/14175665/135774289-6adbd4d2-6fe8-4188-a3a1-2ff368780189.png)


As I am a new user of goldilocks, let me know if those filters are not the correct ones.

