### PR TITLE
Fixing issue where goreleaser picks incorrect tag when multiple tags exist for a single commit hash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,7 @@ jobs:
           registry: "quay.io"
           username: $FAIRWINDS_QUAY_USER
           password-variable: FAIRWINDS_QUAY_TOKEN
+      - run: echo 'export GORELEASER_CURRENT_TAG="${CIRCLE_TAG}"' >> $BASH_ENV
       - run: goreleaser
   snapshot:
     working_directory: /go/src/github.com/fairwindsops/goldilocks


### PR DESCRIPTION
There is an issue with goreleaser where it may choose the incorrect tag if there are multiple tags for a given commit hash. We hit this issue in a recent release where it kept using the release candidate tag name despite the most recent tag being the actual release. This should fix that problem.