### PR TITLE
Add opencontainers labels to Dockerfile (#410)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,14 @@
 FROM alpine:3.15.0
 
+LABEL org.opencontainers.image.authors="FairwindsOps, Inc." \
+      org.opencontainers.image.vendor="FairwindsOps, Inc." \
+      org.opencontainers.image.title="goldilocks" \
+      org.opencontainers.image.description="Goldilocks is a utility that can help you identify a starting point for resource requests and limits." \
+      org.opencontainers.image.documentation="https://goldilocks.docs.fairwinds.com/" \
+      org.opencontainers.image.source="https://github.com/FairwindsOps/goldilocks" \
+      org.opencontainers.image.url="https://github.com/FairwindsOps/goldilocks" \
+      org.opencontainers.image.licenses="Apache License 2.0"
+
 # 'nobody' user in alpine
 USER 65534
 COPY goldilocks /


### PR DESCRIPTION
According to https://github.com/opencontainers/image-spec/blob/main/annotations.md\#pre-defined-annotation-keys

This PR fixes issue #410 

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Provide opencontainers labels in the container image

### What changes did you make?
Added opencontainers labels to the Dockerfile
See: https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
