### PR TITLE
hack/manifests: update rbac.authorization.k8s.io to v1

### DIFF
--- a/hack/manifests/controller/clusterrole.yaml
+++ b/hack/manifests/controller/clusterrole.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: goldilocks-controller

--- a/hack/manifests/controller/clusterrolebinding.yaml
+++ b/hack/manifests/controller/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: goldilocks-controller

--- a/hack/manifests/dashboard/clusterrole.yaml
+++ b/hack/manifests/dashboard/clusterrole.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: goldilocks-dashboard

--- a/hack/manifests/dashboard/clusterrolebinding.yaml
+++ b/hack/manifests/dashboard/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: goldilocks-dashboard


### PR DESCRIPTION
Required for k8s v1.22+, docs say there are no notable changes to the api. See https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122