### PR TITLE
Add a --show-all option to the dashboard to include additional vpas

### DIFF
--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -26,13 +26,17 @@ import (
 	"github.com/fairwindsops/goldilocks/pkg/dashboard"
 )
 
-var serverPort int
+var (
+	serverPort  int
+	showAllVPAs bool
+)
 
 func init() {
 	rootCmd.AddCommand(dashboardCmd)
 	dashboardCmd.PersistentFlags().IntVarP(&serverPort, "port", "p", 8080, "The port to serve the dashboard on.")
 	dashboardCmd.PersistentFlags().StringVarP(&excludeContainers, "exclude-containers", "e", "", "Comma delimited list of containers to exclude from recommendations.")
 	dashboardCmd.PersistentFlags().BoolVar(&onByDefault, "on-by-default", false, "Display every namespace that isn't explicitly excluded.")
+	dashboardCmd.PersistentFlags().BoolVar(&showAllVPAs, "show-all", false, "Display every VPA, even if it isn't managed by Goldilocks")
 }
 
 var dashboardCmd = &cobra.Command{
@@ -44,6 +48,7 @@ var dashboardCmd = &cobra.Command{
 			dashboard.OnPort(serverPort),
 			dashboard.ExcludeContainers(sets.NewString(strings.Split(excludeContainers, ",")...)),
 			dashboard.OnByDefault(onByDefault),
+			dashboard.ShowAllVPAs(showAllVPAs),
 		)
 		http.Handle("/", router)
 		klog.Infof("Starting goldilocks dashboard server on port %d", serverPort)

--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -33,10 +33,15 @@ func Dashboard(opts Options) http.Handler {
 			namespace = val
 		}
 
+		filterLabels := make(map[string]string)
+		if !opts.showAllVPAs {
+			filterLabels = opts.vpaLabels
+		}
+
 		// TODO [hkatz] add caching or refresh button support
 		summarizer := summary.NewSummarizer(
 			summary.ForNamespace(namespace),
-			summary.ForVPAsWithLabels(opts.vpaLabels),
+			summary.ForVPAsWithLabels(filterLabels),
 			summary.ExcludeContainers(opts.excludedContainers),
 		)
 

--- a/pkg/dashboard/namespace-list.go
+++ b/pkg/dashboard/namespace-list.go
@@ -16,7 +16,7 @@ import (
 func NamespaceList(opts Options) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var listOptions v1.ListOptions
-		if opts.onByDefault {
+		if opts.onByDefault || opts.showAllVPAs {
 			listOptions = v1.ListOptions{
 				LabelSelector: fmt.Sprintf("%s!=false", utils.VpaEnabledLabel),
 			}

--- a/pkg/dashboard/options.go
+++ b/pkg/dashboard/options.go
@@ -15,6 +15,7 @@ type Options struct {
 	vpaLabels          map[string]string
 	excludedContainers sets.String
 	onByDefault        bool
+	showAllVPAs        bool
 }
 
 // default options for the dashboard
@@ -25,6 +26,7 @@ func defaultOptions() *Options {
 		vpaLabels:          utils.VPALabels,
 		excludedContainers: sets.NewString(),
 		onByDefault:        false,
+		showAllVPAs:        false,
 	}
 }
 
@@ -53,5 +55,11 @@ func ForVPAsWithLabels(vpaLabels map[string]string) Option {
 func OnByDefault(onByDefault bool) Option {
 	return func(opts *Options) {
 		opts.onByDefault = onByDefault
+	}
+}
+
+func ShowAllVPAs(showAllVPAs bool) Option {
+	return func(opts *Options) {
+		opts.showAllVPAs = showAllVPAs
 	}
 }

--- a/pkg/summary/summary.go
+++ b/pkg/summary/summary.go
@@ -288,7 +288,6 @@ func (s *Summarizer) updateWorkloads() error {
 	for _, w := range workloads {
 		for _, v := range s.vpas {
 			w := w
-			v := v
 			if vpaMatchesWorkload(v, w) {
 				vpaName := v.Name
 				s.workloadForVPANamed[vpaName] = &w


### PR DESCRIPTION
This PR fixes #206

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Allow displaying all VPA objects in the cluster on the dashboard

### What changes did you make?
- Add a flag to the dashboard command
- Add a dashboard option for showAll
- Modify the namespace filtering logic in dashboard
- Update summary package to not require the naming convention to find VPAs associated with workloads

### What alternative solution should we consider, if any?

It might be better (in the future), to clean up the way we handle this, and at the same time allow "adopting" vpas into Goldilocks. For now, I think this is the simplest solution for most folks according to requests in the related issue.