### PR TITLE
Fix small typo in `clean` make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ clean:
 	$(GOCMD) fmt ./...
 	rm -f $(BINARY_NAME)
 	packr2 clean
-	rm -rf e2e/resutls/*
+	rm -rf e2e/results/*
 	rm *-report*
 	rm coverage.txt
 # Cross compilation


### PR DESCRIPTION
This PR fixes #

## Checklist
* [ ] I have signed the CLA
* [ ] I have updated/added any relevant documentation

## Description

Just noticed this when trying to run the `clean` command and the `results/` dir was persisting.

### What's the goal of this PR?

### What changes did you make?

### What alternative solution should we consider, if any?
