### PR TITLE
update GKE notes section with difference between GKE Autopilot and St…

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -25,7 +25,7 @@ The full VPA install includes the updater and the admission webhook for VPA. Gol
 
 ### GKE Notes
 
-Google has provided the vertical pod autoscaler as a beta feature in GKE. You can see the docs [here](https://cloud.google.com/kubernetes-engine/docs/how-to/vertical-pod-autoscaling), or just enable it like so:
+[VPA](https://cloud.google.com/kubernetes-engine/docs/concepts/verticalpodautoscaler) is enabled by default in Autopilot clusters, but you must [manually enable it in Standard clusters](https://cloud.google.com/kubernetes-engine/docs/how-to/vertical-pod-autoscaling). You can enable it like so: 
 
 ```
 gcloud container clusters update [CLUSTER-NAME] --enable-vertical-pod-autoscaling {--region [REGION-NAME] | --zone [ZONE-NAME]}


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
To update the GKE notes in the installation instructions. 

### What changes did you make?
I added a note about the difference between VPA in GKE autopilot and standard. VPA is no longer in Beta in GKE.

### What alternative solution should we consider, if any?
Please double check my work. I see the sentence "Vertical Pod autoscaling is enabled by default in Autopilot clusters." in the [GKE VPA docs](https://cloud.google.com/kubernetes-engine/docs/concepts/verticalpodautoscaler), but it's possible I'm not reading it right. 

Also, HI ANDY!! 


