### PR TITLE
Make headings only contain heading content

### DIFF
--- a/pkg/dashboard/assets/css/main.css
+++ b/pkg/dashboard/assets/css/main.css
@@ -402,6 +402,18 @@ COMPONENTS
   color: var(--color-accent-2);
 }
 
+.layoutCluster {
+  align-items: center;
+  gap: var(--gap--2);
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.layoutCluster.--start {
+  justify-content: start;
+}
+
 .layoutLineup {
   display: flex;
   flex-wrap: wrap;
@@ -855,7 +867,6 @@ input[type="number"] {
 
 .lower-number {
   font-size: 1.25rem;
-  font-weight: normal;
 }
 
 .lower-number--negative {

--- a/pkg/dashboard/templates/container.gohtml
+++ b/pkg/dashboard/templates/container.gohtml
@@ -17,16 +17,15 @@
 {{ $uuid := getUUID }}
 
 <section class="detailInfo --qos verticalRhythm">
-  <h5>
-    <a href="#guaranteed-qos"
-      >Guaranteed <abbr title="Quality of Service">QoS</abbr></a
-    >
+  <div class="layoutCluster --start">
+    <h5>Guaranteed QoS</h5>
+
     {{if lt $.GuaranteedCostInt 0}}
-      <span class="lower-number lower-number--negative">-${{$.GuaranteedCost}}/hour</span>
+      <p class="lower-number lower-number--negative">-${{$.GuaranteedCost}}/hour</p>
     {{else}}
-      <span class="lower-number lower-number--positive">+${{$.GuaranteedCost}}/hour</span>
+      <p class="lower-number lower-number--positive">+${{$.GuaranteedCost}}/hour</p>
     {{end}}
-  </h5>
+  </div>
 
   <table class="compTable callout">
     <caption class="visually-hidden">
@@ -110,16 +109,15 @@
 </section>
 
 <section class="detailInfo --qos verticalRhythm">
-  <h5>
-    <a href="#burstable-qos"
-      >Burstable <abbr title="Quality of Service">QoS</abbr></a
-    >
+  <div class="layoutCluster --start">
+    <h5>Burstable QoS</h5>
+
     {{if lt $.BurstableCostInt 0}}
-      <span class="lower-number lower-number--negative">-${{$.BurstableCost}}/hour</span>
+      <p class="lower-number lower-number--negative">-${{$.BurstableCost}}/hour</p>
     {{else}}
-      <span class="lower-number lower-number--positive">+${{$.BurstableCost}}/hour</span>
+      <p class="lower-number lower-number--positive">+${{$.BurstableCost}}/hour</p>
     {{end}}
-  </h5>
+  </div>
 
   <table class="compTable callout">
     <caption class="visually-hidden">


### PR DESCRIPTION
This PR does not address any Issues.

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
There are a few issues with the Guaranteed and Burstable QoS headings:

1. They contain cost data which isn't actually part of the heading. This is an accessibility issue because it's read as if it were part of the heading and shows up in the document outline when using a screen reader.
2. They contain `<abbr>` elements with `title` attributes that cause the headings to be read out by screen readers differently than they appear.
3. They link to the glossary. The more common convention for a heading containing a link is that it links to itself, enabling someone to jump back to that same spot on the page. Going against common convention can be confusing.

### What changes did you make?

1. Moved the cost data out of the headings.
2. Removed the `<abbr>` elements. There's already a glossary on the same page.
3. Removed the glossary links.

### What alternative solution should we consider, if any?
These changes are meant to improve accessibility and make the HTML less complex. It's possible there are other ways to accomplish these goals, but I'm not sure what an alternative might be.
