### PR TITLE
Add an /api endpoint to the dashboard

### DIFF
--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -47,46 +47,11 @@ func Dashboard(opts Options) http.Handler {
 			namespace = val
 		}
 
-		filterLabels := make(map[string]string)
-		if !opts.showAllVPAs {
-			filterLabels = opts.vpaLabels
-		}
-
-		// TODO [hkatz] add caching or refresh button support
-		summarizer := summary.NewSummarizer(
-			summary.ForNamespace(namespace),
-			summary.ForVPAsWithLabels(filterLabels),
-			summary.ExcludeContainers(opts.excludedContainers),
-		)
-
-		vpaData, err := summarizer.GetSummary()
+		vpaData, err := getVPAData(opts, namespace, costPerCPU, costPerGB)
 		if err != nil {
-			klog.Errorf("Error getting vpaData: %v", err)
-			http.Error(w, "Error running summary.", http.StatusInternalServerError)
+			klog.Errorf("Error getting vpa data %v", err)
+			http.Error(w, "Error getting vpa data", http.StatusInternalServerError)
 			return
-		}
-
-		if costPerCPU != "" && costPerGB != "" {
-			costPerCPUFloat, _ := strconv.ParseFloat(costPerCPU, 64)
-			costPerGBFloat, _ := strconv.ParseFloat(costPerGB, 64)
-
-			var containerCost, guaranteedCost, burstableCost float64
-
-			for _, n := range vpaData.Namespaces {
-				for _, w := range n.Workloads {
-					for k, c := range w.Containers {
-						containerCost = calculateContainerCost(costPerCPUFloat, costPerGBFloat, c)
-						guaranteedCost, burstableCost = calculateRecommendedCosts(costPerCPUFloat, costPerGBFloat, containerCost, c)
-						c.ContainerCost = containerCost
-						c.ContainerCostInt = getCostInt(containerCost)
-						c.GuaranteedCostInt = getCostInt(guaranteedCost)
-						c.BurstableCostInt = getCostInt(burstableCost)
-						c.GuaranteedCost = math.Abs(guaranteedCost)
-						c.BurstableCost = math.Abs(burstableCost)
-						w.Containers[k] = c
-					}
-				}
-			}
 		}
 
 		tmpl, err := getTemplate("dashboard",
@@ -114,6 +79,96 @@ func Dashboard(opts Options) http.Handler {
 
 		writeTemplate(tmpl, opts, &data, w)
 	})
+}
+
+// Dashboard replies with the rendered dashboard (on the basePath) for the summarizer
+func API(opts Options) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+
+		costPerCPU := r.URL.Query().Get("costPerCPU")
+		costPerGB := r.URL.Query().Get("costPerGB")
+
+		var namespace string
+		if val, ok := vars["namespace"]; ok {
+			namespace = val
+		}
+
+		vpaData, err := getVPAData(opts, namespace, costPerCPU, costPerGB)
+		if err != nil {
+			klog.Errorf("Error getting vpa data %v", err)
+			http.Error(w, "Error getting vpa data", http.StatusInternalServerError)
+			return
+		}
+
+		tmpl, err := getTemplate("dashboard",
+			"container",
+			"dashboard",
+			"filter",
+			"namespace",
+			"email",
+			"api_token",
+			"cost_settings",
+		)
+		if err != nil {
+			klog.Errorf("Error getting template data %v", err)
+			http.Error(w, "Error getting template data", http.StatusInternalServerError)
+			return
+		}
+
+		data := struct {
+			VpaData      summary.Summary
+			InsightsHost string
+		}{
+			VpaData:      vpaData,
+			InsightsHost: opts.insightsHost,
+		}
+
+		writeTemplate(tmpl, opts, &data, w)
+	})
+}
+
+func getVPAData(opts Options, namespace, costPerCPU, costPerGB string) (summary.Summary, error) {
+
+	filterLabels := make(map[string]string)
+	if !opts.showAllVPAs {
+		filterLabels = opts.vpaLabels
+	}
+
+	summarizer := summary.NewSummarizer(
+		summary.ForNamespace(namespace),
+		summary.ForVPAsWithLabels(filterLabels),
+		summary.ExcludeContainers(opts.excludedContainers),
+	)
+
+	vpaData, err := summarizer.GetSummary()
+	if err != nil {
+		return summary.Summary{}, err
+	}
+
+	if costPerCPU != "" && costPerGB != "" {
+		costPerCPUFloat, _ := strconv.ParseFloat(costPerCPU, 64)
+		costPerGBFloat, _ := strconv.ParseFloat(costPerGB, 64)
+
+		var containerCost, guaranteedCost, burstableCost float64
+
+		for _, n := range vpaData.Namespaces {
+			for _, w := range n.Workloads {
+				for k, c := range w.Containers {
+					containerCost = calculateContainerCost(costPerCPUFloat, costPerGBFloat, c)
+					guaranteedCost, burstableCost = calculateRecommendedCosts(costPerCPUFloat, costPerGBFloat, containerCost, c)
+					c.ContainerCost = containerCost
+					c.ContainerCostInt = getCostInt(containerCost)
+					c.GuaranteedCostInt = getCostInt(guaranteedCost)
+					c.BurstableCostInt = getCostInt(burstableCost)
+					c.GuaranteedCost = math.Abs(guaranteedCost)
+					c.BurstableCost = math.Abs(burstableCost)
+					w.Containers[k] = c
+				}
+			}
+		}
+	}
+	return vpaData, nil
 }
 
 func calculateContainerCost(costPerCPUFloat float64, costPerGBFloat float64, c summary.ContainerSummary) float64 {

--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -15,6 +15,7 @@
 package dashboard
 
 import (
+	"encoding/json"
 	"math"
 	"net/http"
 	"strconv"
@@ -101,30 +102,12 @@ func API(opts Options) http.Handler {
 			return
 		}
 
-		tmpl, err := getTemplate("dashboard",
-			"container",
-			"dashboard",
-			"filter",
-			"namespace",
-			"email",
-			"api_token",
-			"cost_settings",
-		)
-		if err != nil {
-			klog.Errorf("Error getting template data %v", err)
-			http.Error(w, "Error getting template data", http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(vpaData); err != nil {
+			klog.Errorf("Error writing vpa data %v", err)
+			http.Error(w, "Error writing vpa data", http.StatusInternalServerError)
 			return
 		}
-
-		data := struct {
-			VpaData      summary.Summary
-			InsightsHost string
-		}{
-			VpaData:      vpaData,
-			InsightsHost: opts.insightsHost,
-		}
-
-		writeTemplate(tmpl, opts, &data, w)
 	})
 }
 

--- a/pkg/dashboard/dashboard.go
+++ b/pkg/dashboard/dashboard.go
@@ -82,7 +82,7 @@ func Dashboard(opts Options) http.Handler {
 	})
 }
 
-// Dashboard replies with the rendered dashboard (on the basePath) for the summarizer
+// API replies with the JSON data of the VPA summary
 func API(opts Options) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)

--- a/pkg/dashboard/router.go
+++ b/pkg/dashboard/router.go
@@ -83,6 +83,6 @@ func GetRouter(setters ...Option) *mux.Router {
 	})
 
 	// api
-	router.Handle("/", API(*opts))
+	router.Handle("/api", API(*opts))
 	return router
 }

--- a/pkg/dashboard/router.go
+++ b/pkg/dashboard/router.go
@@ -15,9 +15,10 @@
 package dashboard
 
 import (
-	"k8s.io/klog/v2"
 	"net/http"
 	"path"
+
+	"k8s.io/klog/v2"
 
 	packr "github.com/gobuffalo/packr/v2"
 	"github.com/gorilla/mux"
@@ -81,5 +82,7 @@ func GetRouter(setters ...Option) *mux.Router {
 		http.Redirect(w, r, path.Join(opts.basePath, "/namespaces"), http.StatusMovedPermanently)
 	})
 
+	// api
+	router.Handle("/", API(*opts))
 	return router
 }

--- a/pkg/dashboard/router.go
+++ b/pkg/dashboard/router.go
@@ -83,6 +83,6 @@ func GetRouter(setters ...Option) *mux.Router {
 	})
 
 	// api
-	router.Handle("/api", API(*opts))
+	router.Handle("/api/{namespace:[a-zA-Z0-9-]+}", API(*opts))
 	return router
 }


### PR DESCRIPTION
This PR fixes #585

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Add back the /api endpoint that returned a JSON object of the summary data.

### What changes did you make?
Add an /api handler that serves JSON
Refactor the dashboard code a little bit to reduce duplication for this PR.

### What alternative solution should we consider, if any?
n/a