### PR TITLE
Increase verbose level for common operations

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -181,7 +181,7 @@ func createController(kubeClient kubernetes.Interface, informer cache.SharedInde
 			evt.EventType = "create"
 			evt.ResourceType = resource
 			evt.Namespace = objectMeta(obj).Namespace
-			klog.Infof("%s/%s has been added.", resource, evt.Key)
+			klog.V(2).Infof("%s/%s has been added.", resource, evt.Key)
 			wq.Add(evt)
 		},
 		DeleteFunc: func(obj interface{}) {
@@ -195,7 +195,7 @@ func createController(kubeClient kubernetes.Interface, informer cache.SharedInde
 			evt.EventType = "delete"
 			evt.ResourceType = resource
 			evt.Namespace = objectMeta(obj).Namespace
-			klog.Infof("%s/%s has been deleted.", resource, evt.Key)
+			klog.V(2).Infof("%s/%s has been deleted.", resource, evt.Key)
 			wq.Add(evt)
 		},
 		UpdateFunc: func(old interface{}, new interface{}) {

--- a/pkg/vpa/vpa.go
+++ b/pkg/vpa/vpa.go
@@ -323,7 +323,7 @@ func (r Reconciler) updateVPA(vpa vpav1.VerticalPodAutoscaler) error {
 			klog.Errorf("Error updating VPA/%s in Namespace/%s: %v", vpa.Name, vpa.Namespace, retryErr)
 			return retryErr
 		}
-		klog.Infof("Updated VPA/%s in Namespace/%s", vpa.Name, vpa.Namespace)
+		klog.V(2).Infof("Updated VPA/%s in Namespace/%s", vpa.Name, vpa.Namespace)
 	} else {
 		klog.Infof("Not updating VPA/%s in Namespace/%s due to dryrun.", vpa.Name, vpa.Namespace)
 	}


### PR DESCRIPTION
This PR fixes #564

## Checklist
* [x] I have signed the CLA
* [ ] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Allow to significantly reduce the noise of the logs by setting the log level to `1`, without turning off logs completely or affecting default functionality.

### What changes did you make?

Increases the verbose level for common operation logs to `2` (which is the default log level). 

### What alternative solution should we consider, if any?

