### PR TITLE
fix: add cluster roles to list and monitor jobs and cronjobs

### DIFF
--- a/hack/manifests/controller/clusterrole.yaml
+++ b/hack/manifests/controller/clusterrole.yaml
@@ -15,6 +15,15 @@ rules:
       - 'list'
       - 'watch'
   - apiGroups:
+      - 'batch'
+    resources:
+      - 'cronjobs'
+      - 'jobs'
+    verbs:
+      - 'get'
+      - 'list'
+      - 'watch'
+  - apiGroups:
       - ''
     resources:
       - 'namespaces'


### PR DESCRIPTION
This PR fixes #

## Checklist
* [ ] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

We get many error logs reporting that the controller can't get/list jobs and cronjobs compute
tasks.

```
 goldilocks-controller-7c9cb58864-pndwb goldilocks E0717 13:43:19.711591       1 controller.go:229]  "msg"="Error retrieving parent object" "error"="jobs.batch is forbidden: User \"system:serviceaccount:[redacted]-system:goldilocks-controller\" cannot list resource \"jobs\" in API group \"batch\" in the namespace \"kube-system\"" "v1"="jobs"
```


### What changes did you make?

add the list/get/watch permission for the controller clusterrole

### What alternative solution should we consider, if any?

idk
