### PR TITLE
Allow setting minimum replicas for eviction on VPAs

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -26,6 +26,8 @@ var (
 	VpaEnabledLabel = LabelOrAnnotationBase + "/" + "enabled"
 	// VpaUpdateModeKey is the label used to indicate the vpa update mode.
 	VpaUpdateModeKey = LabelOrAnnotationBase + "/" + "vpa-update-mode"
+	// VpaMinReplicas is the annotation to use to define minimum replicas for eviction of a VPA
+	VpaMinReplicasAnnotation = LabelOrAnnotationBase + "/" + "vpa-min-replicas"
 	// DeploymentExcludeContainersAnnotation is the label used to exclude container names from being reported.
 	WorkloadExcludeContainersAnnotation = LabelOrAnnotationBase + "/" + "exclude-containers"
 	// VpaResourcePolicyAnnotation is the annotation use to define the json configuration of PodResourcePolicy section of a vpa

--- a/pkg/vpa/vpa_test.go
+++ b/pkg/vpa/vpa_test.go
@@ -211,7 +211,7 @@ func Test_createVPAWithResourcePolicy(t *testing.T) {
 	updateMode, _ := vpaUpdateModeForResource(&nsLabeledResourcePolicy)
 	resourcePolicy, _ := vpaResourcePolicyForResource(&nsLabeledResourcePolicy)
 	minReplicas, _ := vpaMinReplicasForResource(&nsLabeledResourcePolicy)
-	testVPA := rec.getVPAObject(nil, &nsTesting, controller, updateMode, resourcePolicy, minReplicas)
+	testVPA := rec.getVPAObject(nil, &nsLabeledResourcePolicy, controller, updateMode, resourcePolicy, minReplicas)
 
 	errCreate := rec.createVPA(testVPA)
 	newVPA, _ := VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(nsLabeledResourcePolicy.Name).Get(context.TODO(), "goldilocks-test-vpa", metav1.GetOptions{})

--- a/pkg/vpa/vpa_test.go
+++ b/pkg/vpa/vpa_test.go
@@ -274,8 +274,8 @@ func Test_updateVPA(t *testing.T) {
 	}
 	updateMode, _ := vpaUpdateModeForResource(testNS)
 	resourcePolicy, _ := vpaResourcePolicyForResource(testNS)
-	minReplicas, _ := vpaMinReplicasForResource(&nsTesting)
-	testVPA := rec.getVPAObject(nil, &nsTesting, controller, updateMode, resourcePolicy, minReplicas)
+	minReplicas, _ := vpaMinReplicasForResource(testNS)
+	testVPA := rec.getVPAObject(nil, testNS, controller, updateMode, resourcePolicy, minReplicas)
 
 	_, err := VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(testNS.Name).Create(context.TODO(), &testVPA, metav1.CreateOptions{})
 	assert.NoError(t, err)

--- a/pkg/vpa/vpa_test.go
+++ b/pkg/vpa/vpa_test.go
@@ -141,8 +141,9 @@ func Test_getVPAObject(t *testing.T) {
 			t.Parallel()
 
 			mode, _ := vpaUpdateModeForResource(test.ns)
-			resoucePolicy, _ := vpaResourcePolicyForResource(test.ns)
-			vpa := rec.getVPAObject(test.vpa, test.ns, test.controller, mode, resoucePolicy)
+			resourcePolicy, _ := vpaResourcePolicyForResource(test.ns)
+			minReplicas, _ := vpaMinReplicasForResource(test.ns)
+			vpa := rec.getVPAObject(test.vpa, test.ns, test.controller, mode, resourcePolicy, minReplicas)
 
 			// expected ObjectMeta
 			assert.Equal(t, "goldilocks-test-vpa", vpa.Name)
@@ -175,8 +176,9 @@ func Test_createVPA(t *testing.T) {
 	}
 
 	updateMode, _ := vpaUpdateModeForResource(&nsTesting)
-	resoucePolicy, _ := vpaResourcePolicyForResource(&nsTesting)
-	testVPA := rec.getVPAObject(nil, &nsTesting, controller, updateMode, resoucePolicy)
+	resourcePolicy, _ := vpaResourcePolicyForResource(&nsTesting)
+	minReplicas, _ := vpaMinReplicasForResource(&nsTesting)
+	testVPA := rec.getVPAObject(nil, &nsTesting, controller, updateMode, resourcePolicy, minReplicas)
 
 	err := rec.createVPA(testVPA)
 	assert.NoError(t, err)
@@ -207,8 +209,9 @@ func Test_createVPAWithResourcePolicy(t *testing.T) {
 	rec.DryRun = false
 
 	updateMode, _ := vpaUpdateModeForResource(&nsLabeledResourcePolicy)
-	resoucePolicy, _ := vpaResourcePolicyForResource(&nsLabeledResourcePolicy)
-	testVPA := rec.getVPAObject(nil, &nsLabeledResourcePolicy, controller, updateMode, resoucePolicy)
+	resourcePolicy, _ := vpaResourcePolicyForResource(&nsLabeledResourcePolicy)
+	minReplicas, _ := vpaMinReplicasForResource(&nsLabeledResourcePolicy)
+	testVPA := rec.getVPAObject(nil, &nsTesting, controller, updateMode, resourcePolicy, minReplicas)
 
 	errCreate := rec.createVPA(testVPA)
 	newVPA, _ := VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(nsLabeledResourcePolicy.Name).Get(context.TODO(), "goldilocks-test-vpa", metav1.GetOptions{})
@@ -232,8 +235,10 @@ func Test_deleteVPA(t *testing.T) {
 		Unstructured: nil,
 	}
 	updateMode, _ := vpaUpdateModeForResource(&nsTesting)
-	resoucePolicy, _ := vpaResourcePolicyForResource(&nsTesting)
-	testVPA := rec.getVPAObject(nil, &nsTesting, controller, updateMode, resoucePolicy)
+	resourcePolicy, _ := vpaResourcePolicyForResource(&nsTesting)
+	minReplicas, _ := vpaMinReplicasForResource(&nsTesting)
+	testVPA := rec.getVPAObject(nil, &nsTesting, controller, updateMode, resourcePolicy, minReplicas)
+
 	_, err := VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(nsTesting.Name).Create(context.TODO(), &testVPA, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
@@ -268,8 +273,10 @@ func Test_updateVPA(t *testing.T) {
 		Unstructured: nil,
 	}
 	updateMode, _ := vpaUpdateModeForResource(testNS)
-	resoucePolicy, _ := vpaResourcePolicyForResource(testNS)
-	testVPA := rec.getVPAObject(nil, testNS, controller, updateMode, resoucePolicy)
+	resourcePolicy, _ := vpaResourcePolicyForResource(testNS)
+	minReplicas, _ := vpaMinReplicasForResource(&nsTesting)
+	testVPA := rec.getVPAObject(nil, &nsTesting, controller, updateMode, resourcePolicy, minReplicas)
+
 	_, err := VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(testNS.Name).Create(context.TODO(), &testVPA, metav1.CreateOptions{})
 	assert.NoError(t, err)
 
@@ -290,8 +297,9 @@ func Test_updateVPA(t *testing.T) {
 	// change the update mode
 	testNS.Labels["goldilocks.fairwinds.com/vpa-update-mode"] = "auto"
 	updateMode, _ = vpaUpdateModeForResource(testNS)
-	resoucePolicy, _ = vpaResourcePolicyForResource(testNS)
-	newVPA := rec.getVPAObject(nil, testNS, controller, updateMode, resoucePolicy)
+	resourcePolicy, _ = vpaResourcePolicyForResource(testNS)
+	minReplicas, _ = vpaMinReplicasForResource(testNS)
+	newVPA := rec.getVPAObject(nil, testNS, controller, updateMode, resourcePolicy, minReplicas)
 
 	errUpdate2 := rec.updateVPA(newVPA)
 	assert.NoError(t, errUpdate2)
@@ -335,12 +343,14 @@ func Test_listVPA(t *testing.T) {
 	// test vpas
 	updateMode1, _ := vpaUpdateModeForResource(testNS1)
 	updateMode2, _ := vpaUpdateModeForResource(testNS2)
-	resoucePolicy1, _ := vpaResourcePolicyForResource(testNS1)
-	resoucePolicy2, _ := vpaResourcePolicyForResource(testNS2)
+	resourcePolicy1, _ := vpaResourcePolicyForResource(testNS1)
+	resourcePolicy2, _ := vpaResourcePolicyForResource(testNS2)
+	minReplicas1, _ := vpaMinReplicasForResource(testNS1)
+	minReplicas2, _ := vpaMinReplicasForResource(testNS2)
 
-	vpa1 := rec.getVPAObject(nil, testNS1, controller1, updateMode1, resoucePolicy1)
-	vpa2 := rec.getVPAObject(nil, testNS1, controller2, updateMode1, resoucePolicy1)
-	vpa3 := rec.getVPAObject(nil, testNS2, controller3, updateMode2, resoucePolicy2)
+	vpa1 := rec.getVPAObject(nil, testNS1, controller1, updateMode1, resourcePolicy1, minReplicas1)
+	vpa2 := rec.getVPAObject(nil, testNS1, controller2, updateMode1, resourcePolicy1, minReplicas1)
+	vpa3 := rec.getVPAObject(nil, testNS2, controller3, updateMode2, resourcePolicy2, minReplicas2)
 
 	// create vpas
 	_ = rec.createVPA(vpa1)


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Enable VPA to evict pods that have only 1 replica by setting an annotation on them

### What changes did you make?
Add functions similar to the vpaUpdateMode that control the minreplicas on the podUpdatePolicy

### What alternative solution should we consider, if any?
Can't think of anything