### PR TITLE
Dont create VPA if has conflicting HPA or VPA

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -17,7 +17,9 @@ package handler
 import (
 	"strings"
 
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
+	vpav1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/klog/v2"
 
 	"github.com/fairwindsops/goldilocks/pkg/utils"
@@ -37,6 +39,10 @@ func OnUpdate(obj interface{}, event utils.Event) {
 		OnPodChanged(obj.(*corev1.Pod), event)
 	case *corev1.Namespace:
 		OnNamespaceChanged(obj.(*corev1.Namespace), event)
+	case *vpav1.VerticalPodAutoscaler:
+		OnVPAChanged(obj.(*vpav1.VerticalPodAutoscaler), event)
+	case *autoscalingv2.HorizontalPodAutoscaler:
+		OnHPAChanged(obj.(*autoscalingv2.HorizontalPodAutoscaler), event)
 	default:
 		klog.Errorf("Object has unknown type of %T", t)
 	}
@@ -49,6 +55,10 @@ func onDelete(event utils.Event) {
 		OnNamespaceChanged(&corev1.Namespace{}, event)
 	case "pod":
 		OnPodChanged(&corev1.Pod{}, event)
+	case "vpa":
+		OnVPAChanged(&vpav1.VerticalPodAutoscaler{}, event)
+	case "hpa":
+		OnHPAChanged(&autoscalingv2.HorizontalPodAutoscaler{}, event)
 	default:
 		klog.Errorf("object has unknown resource type %s", event.ResourceType)
 	}

--- a/pkg/handler/hpa.go
+++ b/pkg/handler/hpa.go
@@ -1,0 +1,28 @@
+package handler
+
+import (
+	"github.com/davecgh/go-spew/spew"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	"k8s.io/klog/v2"
+
+	"github.com/fairwindsops/goldilocks/pkg/kube"
+	"github.com/fairwindsops/goldilocks/pkg/utils"
+	"github.com/fairwindsops/goldilocks/pkg/vpa"
+)
+
+func OnHPAChanged(hpa *autoscalingv2.HorizontalPodAutoscaler, event utils.Event) {
+	kubeClient := kube.GetInstance()
+	namespace, err := kube.GetNamespace(kubeClient, event.Namespace)
+	if err != nil {
+		klog.Error("handler got error retrieving namespace object. breaking.")
+		klog.V(5).Info("dumping out event struct")
+		klog.V(5).Info(spew.Sdump(event))
+		return
+	}
+
+	klog.V(3).Infof("HPA %s/%s updated. Reconciling namespace.", hpa.Namespace, hpa.Name)
+	err = vpa.GetInstance().ReconcileNamespace(namespace)
+	if err != nil {
+		klog.Errorf("Error reconciling: %v", err)
+	}
+}

--- a/pkg/handler/vpa.go
+++ b/pkg/handler/vpa.go
@@ -1,0 +1,28 @@
+package handler
+
+import (
+	"github.com/davecgh/go-spew/spew"
+	vpav1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/klog/v2"
+
+	"github.com/fairwindsops/goldilocks/pkg/kube"
+	"github.com/fairwindsops/goldilocks/pkg/utils"
+	goldilocksvpa "github.com/fairwindsops/goldilocks/pkg/vpa"
+)
+
+func OnVPAChanged(vpa *vpav1.VerticalPodAutoscaler, event utils.Event) {
+	kubeClient := kube.GetInstance()
+	namespace, err := kube.GetNamespace(kubeClient, event.Namespace)
+	if err != nil {
+		klog.Error("handler got error retrieving namespace object. breaking.")
+		klog.V(5).Info("dumping out event struct")
+		klog.V(5).Info(spew.Sdump(event))
+		return
+	}
+
+	klog.V(3).Infof("VPA %s/%s updated. Reconciling namespace.", vpa.Namespace, vpa.Name)
+	err = goldilocksvpa.GetInstance().ReconcileNamespace(namespace)
+	if err != nil {
+		klog.Errorf("Error reconciling: %v", err)
+	}
+}

--- a/pkg/kube/test_helpers.go
+++ b/pkg/kube/test_helpers.go
@@ -48,7 +48,8 @@ func GetMockDynamicClient() *DynamicClientInstance {
 	gvapps := schema.GroupVersion{Group: "apps", Version: "v1"}
 	gvcore := schema.GroupVersion{Group: "", Version: "v1"}
 	gvbatch := schema.GroupVersion{Group: "batch", Version: "v1"}
-	restMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{gvapps, gvcore, gvbatch})
+	gvautoscaling := schema.GroupVersion{Group: "autoscaling", Version: "v2"}
+	restMapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{gvapps, gvcore, gvbatch, gvautoscaling})
 	gvk := gvapps.WithKind("Deployment")
 	restMapper.Add(gvk, meta.RESTScopeNamespace)
 	gvk = gvapps.WithKind("DaemonSet")
@@ -64,6 +65,8 @@ func GetMockDynamicClient() *DynamicClientInstance {
 	gvk = gvbatch.WithKind("CronJob")
 	restMapper.Add(gvk, meta.RESTScopeNamespace)
 	gvk = gvbatch.WithKind("Job")
+	restMapper.Add(gvk, meta.RESTScopeNamespace)
+	gvk = gvautoscaling.WithKind("HorizontalPodAutoscaler")
 	restMapper.Add(gvk, meta.RESTScopeNamespace)
 	gvrToListKind := map[schema.GroupVersionResource]string{
 		{
@@ -106,6 +109,11 @@ func GetMockDynamicClient() *DynamicClientInstance {
 			Version:  "v1",
 			Resource: "jobs",
 		}: "JobList",
+		{
+			Group:    "autoscaling",
+			Version:  "v2",
+			Resource: "horizontalpodautoscalers",
+		}: "HorizontalPodAutoscalerList",
 	}
 	fc := fakedyn.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind)
 	kc := DynamicClientInstance{

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -17,6 +17,7 @@ package utils
 import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	vpav1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 )
 
 var (
@@ -96,4 +97,20 @@ func FormatResourceList(rl v1.ResourceList) v1.ResourceList {
 		rl[v1.ResourceMemory] = mem
 	}
 	return rl
+}
+
+// VPACreatedByGoldilocks checks if a given VPA is created by Goldilocks.
+func VPACreatedByGoldilocks(vpa *vpav1.VerticalPodAutoscaler) bool {
+	if vpa == nil {
+		return false
+	}
+	if vpa.Labels == nil {
+		return false
+	}
+	for key, value := range VPALabels {
+		if vpa.Labels[key] != value {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/vpa/test_constants.go
+++ b/pkg/vpa/test_constants.go
@@ -15,7 +15,10 @@
 package vpa
 
 import (
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	vpav1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 )
@@ -178,6 +181,32 @@ var testDeploymentUnstructured = &unstructured.Unstructured{
 			"name": "test-deploy",
 		},
 		"spec": map[string]interface{}{},
+	},
+}
+
+var testConflictingVPA = vpav1.VerticalPodAutoscaler{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "conflicting-vpa",
+	},
+	Spec: vpav1.VerticalPodAutoscalerSpec{
+		TargetRef: &autoscalingv1.CrossVersionObjectReference{
+			APIVersion: testDeploymentUnstructured.GetAPIVersion(),
+			Kind:       testDeploymentUnstructured.GroupVersionKind().Kind,
+			Name:       testDeploymentUnstructured.GetName(),
+		},
+	},
+}
+
+var testConflictingHPA = autoscalingv2.HorizontalPodAutoscaler{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "conflicting-hpa",
+	},
+	Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+		ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+			APIVersion: testDeploymentUnstructured.GetAPIVersion(),
+			Kind:       testDeploymentUnstructured.GroupVersionKind().Kind,
+			Name:       testDeploymentUnstructured.GetName(),
+		},
 	},
 }
 


### PR DESCRIPTION
This PR fixes #655

## Checklist
* [x] I have signed the CLA
* [ ] I have updated/added any relevant documentation

## Description

### What's the goal of this PR?
Fixes several issues related to working with existing non-goldilocks managed VPAs and HPAs

1. Do not create VPAs if there're existing non-goldilocks managed VPA objects targeting the same k8s controller.
2. Do not create VPAs if there're existing non-goldilocks managed HPA objects targeting the same k8s controller, given those HPAs use cpu or memory as scale metric.
3. Do not modify or delete non-goldilocks managed VPAs

### What changes did you make?
In each reconcile loop, check for conflicting HPA or VPA objects in the namespace

### What alternative solution should we consider, if any?
N/A
