### PR TITLE
Adding Rollout controller referance deployment

### DIFF
--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -28,10 +28,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	controllerUtils "github.com/fairwindsops/controller-utils/pkg/controller"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
+	appsv1clientset "k8s.io/client-go/kubernetes/typed/apps/v1"
 )
 
 // ClientInstance is a wrapper around the kubernetes interface for testing purposes
@@ -186,4 +188,15 @@ func GetNamespace(kubeClient *ClientInstance, nsName string) (*corev1.Namespace,
 		return nil, err
 	}
 	return namespace, nil
+}
+
+// GetDeployment returns a deployment object when given a name and namespace
+func GetDeployment(client appsv1clientset.AppsV1Interface, namespace, deploymentName string) (*v1.Deployment, error) {
+	deployment, err := client.Deployments(namespace).Get(context.TODO(), deploymentName, metav1.GetOptions{})
+	if err != nil {
+		klog.Errorf("failed to get Deployment: %v", err)
+		return nil, err
+	}
+
+	return deployment, nil
 }

--- a/pkg/summary/summary.go
+++ b/pkg/summary/summary.go
@@ -202,7 +202,7 @@ func (s Summarizer) GetSummary() (Summary, error) {
 				kubeClient := kube.GetInstance()
 
 				workloadPodSpecUnstructuredMetadata, _, _ := unstructured.NestedMap(workload.TopController.UnstructuredContent(), "metadata")
-				workloadPodSpecUnstructured, workloadPodSpecFound, _ = unstructured.NestedMap(workload.TopController.UnstructuredContent(), "spec", "workloadRef")
+				workloadPodSpecUnstructured, _, _ = unstructured.NestedMap(workload.TopController.UnstructuredContent(), "spec", "workloadRef")
 
 				namespace := workloadPodSpecUnstructuredMetadata["namespace"].(string)
 				deployment, err := kube.GetDeployment(kubeClient.Client.AppsV1(), namespace, workloadPodSpecUnstructured["name"].(string))

--- a/pkg/summary/summary.go
+++ b/pkg/summary/summary.go
@@ -198,7 +198,7 @@ func (s Summarizer) GetSummary() (Summary, error) {
 			}
 
 			// On argoRollout controller you can referance Deployment
-			if workload.TopController.GetKind() == "Rollout" {
+			if workload.TopController.GetKind() == "Rollout" && !workloadPodSpecFound {
 				kubeClient := kube.GetInstance()
 
 				workloadPodSpecUnstructuredMetadata, _, _ := unstructured.NestedMap(workload.TopController.UnstructuredContent(), "metadata")


### PR DESCRIPTION
This PR fixes issue like #225 https://github.com/FairwindsOps/goldilocks/issues/225

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
- Fix the Dashboard when you use Rollout which points to Deployment

### What changes did you make?
- Add reference to deployment when Rollout kind detected and spec for Rollout is empty
### What alternative solution should we consider, if any?

