### PR TITLE
Feature/make UI more customizeable and fix bugs

### DIFF
--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -31,8 +31,9 @@ var (
 	showAllVPAs  bool
 	basePath     string
 	insightsHost string
-	enableCost   bool
+	enableCost                    bool
 	enableCPULimitRecommendation  bool
+	enableBurstableRecommendation bool
 )
 
 func init() {
@@ -44,6 +45,8 @@ func init() {
 	dashboardCmd.PersistentFlags().StringVar(&basePath, "base-path", "/", "Path on which the dashboard is served.")
 	dashboardCmd.PersistentFlags().BoolVar(&enableCost, "enable-cost", true, "If set to false, the cost integration will be disabled on the dashboard.")
 	dashboardCmd.PersistentFlags().BoolVar(&enableCPULimitRecommendation, "enable-cpu-limit-recommendation", true, "If set to false, the dashboard will not display cpu limit recommendations")
+	dashboardCmd.PersistentFlags().BoolVar(&enableBurstableRecommendation, "enable-burstable-recommendation", true, "If set to false, the dashboard will not display the burstable QoS information")
+
 	dashboardCmd.PersistentFlags().StringVar(&insightsHost, "insights-host", "https://insights.fairwinds.com", "Insights host for retrieving optional cost data.")
 }
 
@@ -61,6 +64,7 @@ var dashboardCmd = &cobra.Command{
 			dashboard.ShowAllVPAs(showAllVPAs),
 			dashboard.InsightsHost(insightsHost),
 			dashboard.EnableCost(enableCost),
+			dashboard.EnableBurstableRecommendation(enableBurstableRecommendation),
 			dashboard.EnableCPULimitRecommendation(enableCPULimitRecommendation),
 		)
 		http.Handle("/", router)

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -32,6 +32,7 @@ var (
 	basePath     string
 	insightsHost string
 	enableCost   bool
+	enableCPULimitRecommendation  bool
 )
 
 func init() {
@@ -42,6 +43,7 @@ func init() {
 	dashboardCmd.PersistentFlags().BoolVar(&showAllVPAs, "show-all", false, "Display every VPA, even if it isn't managed by Goldilocks")
 	dashboardCmd.PersistentFlags().StringVar(&basePath, "base-path", "/", "Path on which the dashboard is served.")
 	dashboardCmd.PersistentFlags().BoolVar(&enableCost, "enable-cost", true, "If set to false, the cost integration will be disabled on the dashboard.")
+	dashboardCmd.PersistentFlags().BoolVar(&enableCPULimitRecommendation, "enable-cpu-limit-recommendation", true, "If set to false, the dashboard will not display cpu limit recommendations")
 	dashboardCmd.PersistentFlags().StringVar(&insightsHost, "insights-host", "https://insights.fairwinds.com", "Insights host for retrieving optional cost data.")
 }
 
@@ -59,6 +61,7 @@ var dashboardCmd = &cobra.Command{
 			dashboard.ShowAllVPAs(showAllVPAs),
 			dashboard.InsightsHost(insightsHost),
 			dashboard.EnableCost(enableCost),
+			dashboard.EnableCPULimitRecommendation(enableCPULimitRecommendation),
 		)
 		http.Handle("/", router)
 		klog.Infof("Starting goldilocks dashboard server on port %d and basePath %v", serverPort, validBasePath)

--- a/pkg/dashboard/options.go
+++ b/pkg/dashboard/options.go
@@ -18,6 +18,7 @@ type Options struct {
 	ShowAllVPAs        bool
 	InsightsHost       string
 	EnableCost         bool
+	EnableCPULimitRecommendation bool
 }
 
 // default options for the dashboard
@@ -82,5 +83,10 @@ func InsightsHost(insightsHost string) Option {
 func EnableCost(enableCost bool) Option {
 	return func(opts *Options) {
 		opts.EnableCost = enableCost
+	}
+}
+func EnableCPULimitRecommendation(enableCPULimitRecommendation bool) Option {
+	return func(opts *Options) {
+		opts.EnableCPULimitRecommendation = enableCPULimitRecommendation
 	}
 }

--- a/pkg/dashboard/options.go
+++ b/pkg/dashboard/options.go
@@ -19,6 +19,7 @@ type Options struct {
 	InsightsHost       string
 	EnableCost         bool
 	EnableCPULimitRecommendation bool
+	EnableBurstableRecommendation bool
 }
 
 // default options for the dashboard
@@ -83,6 +84,11 @@ func InsightsHost(insightsHost string) Option {
 func EnableCost(enableCost bool) Option {
 	return func(opts *Options) {
 		opts.EnableCost = enableCost
+	}
+}
+func EnableBurstableRecommendation(enableBurstableRecommendation bool) Option {
+	return func(opts *Options) {
+		opts.EnableBurstableRecommendation = enableBurstableRecommendation
 	}
 }
 func EnableCPULimitRecommendation(enableCPULimitRecommendation bool) Option {

--- a/pkg/dashboard/templates/container.gohtml
+++ b/pkg/dashboard/templates/container.gohtml
@@ -20,7 +20,7 @@
 
 <section class="detailInfo --qos verticalRhythm">
   <div class="layoutCluster --start">
-    <h5>Guaranteed QoS</h5>
+    <h5>Recommendations</h5>
 
     {{ if opts.EnableCost }}
     {{ if lt $.GuaranteedCostInt 0 }}
@@ -33,7 +33,7 @@
 
   <table class="compTable callout">
     <caption class="visually-hidden">
-      Compare Current Config to Guaranteed QoS Recommendations
+      Compare Current Config to Recommended settings
     </caption>
 
     <thead>
@@ -41,12 +41,13 @@
         <td></td>
         <th scope="col">Current</th>
         <td></td>
-        <th scope="col">Guaranteed</th>
+        <th scope="col">Recommended</th>
       </tr>
     </thead>
     <tbody>
       <tr>
         <th scope="row">CPU Request</th>
+
         <td>{{ printResource $cpuRequest}}</td>
         <td>
           <i
@@ -126,6 +127,7 @@
   {{end}}
 </section>
 
+{{ if opts.EnableBurstableRecommendation }}
 <section class="detailInfo --qos verticalRhythm">
   <div class="layoutCluster --start">
     <h5>Burstable QoS</h5>

--- a/pkg/dashboard/templates/container.gohtml
+++ b/pkg/dashboard/templates/container.gohtml
@@ -57,7 +57,7 @@
         </td>
         <td>{{ printResource $cpuTarget }}</td>
       </tr>
-
+      {{ if opts.EnableCPULimitRecommendation }}
       <tr>
         <th scope="row">CPU Limit</th>
         <td>{{ printResource $cpuLimit}}</td>
@@ -70,6 +70,7 @@
         </td>
         <td>{{ printResource $cpuTarget }}</td>
       </tr>
+      {{end}}
 
       <tr>
         <th scope="row">Memory Request</th>
@@ -99,6 +100,7 @@
     </tbody>
   </table>
 
+  {{if opts.EnableCPULimitRecommendation}}
   <details>
     <summary>YAML for Recommended Settings</summary>
 
@@ -110,6 +112,18 @@
     cpu: {{ printResource $cpuTarget}}
     memory: {{ printResource $memTarget }}</code></pre>
   </details>
+  {{else}}
+    <details>
+      <summary>YAML for Recommended Settings</summary>
+
+      <pre class="fix-yaml"><code class="language-yaml">resources:
+  requests:
+    cpu: {{ printResource $cpuTarget }}
+    memory: {{ printResource $memTarget }}
+  limits:
+    memory: {{ printResource $memTarget }}</code></pre>
+    </details>
+  {{end}}
 </section>
 
 <section class="detailInfo --qos verticalRhythm">
@@ -151,7 +165,7 @@
         </td>
         <td>{{ printResource $cpuLowerBound }}</td>
       </tr>
-
+      {{if opts.EnableCPULimitRecommendation}}
       <tr>
         <th scope="row">CPU Limit</th>
         <td>{{ printResource $cpuLimit}}</td>
@@ -164,6 +178,7 @@
         </td>
         <td>{{ printResource $cpuUpperBound }}</td>
       </tr>
+      {{end}}
 
       <tr>
         <th scope="row">Memory Request</th>
@@ -193,6 +208,7 @@
     </tbody>
   </table>
 
+  {{if opts.EnableCPULimitRecommendation}}
   <details>
     <summary>YAML for Recommended Settings</summary>
 
@@ -204,5 +220,18 @@
     cpu: {{ printResource $cpuUpperBound}}
     memory: {{ printResource $memUpperBound }}</code></pre>
   </details>
+  {{ else }}
+  <details>
+    <summary>YAML for Recommended Settings</summary>
+
+    <pre class="fix-yaml"><code class="language-yaml">resources:
+  requests:
+    cpu: {{ printResource $cpuLowerBound }}
+    memory: {{ printResource $memLowerBound }}
+  limits:
+    memory: {{ printResource $memUpperBound }}</code></pre>
+  </details>
+  {{ end }}
 </section>
+{{ end }}
 {{ end }}

--- a/pkg/dashboard/templates/head.gohtml
+++ b/pkg/dashboard/templates/head.gohtml
@@ -19,9 +19,9 @@
 <link rel="stylesheet" href="static/css/fontawesome-5.7.2.css" />
 <script src="static/js/main.js" type="module"></script>
 
-{{- if opts.EnableCost }}
+
 <link rel="stylesheet" href="static/css/prism.css" />
 <script defer src="static/js/prism.js"></script>
-{{- end }}
+
 
 {{ end }}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -88,7 +88,7 @@ func FormatResourceList(rl v1.ResourceList) v1.ResourceList {
 	}
 	if mem, exists := rl[v1.ResourceMemory]; exists {
 		i := 0
-		maxAllowableStringLen := 5
+		maxAllowableStringLen := 6
 		for len(mem.String()) > maxAllowableStringLen && i < len(memoryScales)-1 {
 			mem.RoundUp(memoryScales[i])
 			i++

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -120,4 +120,12 @@ var testFormatResourceCases = []struct {
 		resourceType: "memory",
 		expected:     "124M",
 	},
+	{
+		description: "Memory expressed as more than 6 digits (eg 1100Mi) should be persisted and not rounded up",
+		testData: v1.ResourceList{
+			"memory": resource.MustParse("1100Mi"),
+		},
+		resourceType: "memory",
+		expected:     "1100Mi",
+	},
 }


### PR DESCRIPTION
Thanks for a great tool for recommendations in kubernetes! I took some time to improve the code to suit our
organization better, and I hope you can consider merging at least some of these changes so we don't need to maintain our own fork and others can benefit from this too.

This PR fixes #673, #668, #686 

## Checklist
* [x] I have updated/added any relevant documentation
* [x] I have signed the CLA

## Description
This PR fixes some bugs that were present (see the issues linked). It also adds some UI customization options
to the dashboard to make it possible to limit what is shown for a give container. The changes should be fully backwards compatible.

### What's the goal of this PR?
The goal is to fix some bugs that were present that ruined a bit of the experience using this cool product! It also makes it easier to customize the UI to better fit the individual organizations using this.

### What changes did you make?
* [x] Fix UI bug for yaml copy-paste recommendations even if `--enable-cost=false`
* [x] Fix UI bug where 1100Mi (or similar strings of len > 6) would be rendered in Ki instead of just 1100Mi due to a flaw in the roundup logic
* [x] Add option `--enable-cpu-limit-recommendation` which when false will no longer show CPU limit
* [x] Add option `--enable-burstable-recommendation` which when false will no longer show the "Burstable QoS"

### What alternative solution should we consider, if any?
The fix for the `1100Mi` (or similar strings of len > 6) is not optimal, my fix only pushes the problem forward (but writing for example 11000Mi is more unlikely to happen). Optimally we would round it _down_ to something like `1.1Gi` but I didn't have time to investigate how these conversions work in a good way.
There is also the issue that when we are not setting CPU limit, we are technically no longer in the QoS class guaranteed either. In general I think the QoS concept is more confusing than helpful in the dashboard and would see it removed, but I didn't want to make too big changes at this point :+1: 
 

