### PR TITLE
remove erroneous character from release workflow definition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ workflows:
           name: "End-To-End Kubernetes 1.27"
           kind_node_image: "kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72"
           <<: *e2e_configuration
-o release:
+  release:
     jobs:
       - build_and_release:
           filters:


### PR DESCRIPTION

This PR fixes #

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
To fix a typo that I believe is preventing the release workflow to be triggered


### What changes did you make?
Remove typo at beginning of line defining release workflow

### What alternative solution should we consider, if any?

