### PR TITLE
Ability to ignore some controller by Kind

### DIFF
--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -28,6 +28,7 @@ import (
 
 var onByDefault bool
 var includeNamespaces []string
+var ignoreControllerKind []string
 var excludeNamespaces []string
 var dryRun bool
 
@@ -37,6 +38,7 @@ func init() {
 	controllerCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "If true, don't mutate resources, just list what would have been created.")
 	controllerCmd.PersistentFlags().StringSliceVar(&includeNamespaces, "include-namespaces", []string{}, "Comma delimited list of namespaces to include from recommendations.")
 	controllerCmd.PersistentFlags().StringSliceVar(&excludeNamespaces, "exclude-namespaces", []string{}, "Comma delimited list of namespaces to exclude from recommendations.")
+	controllerCmd.PersistentFlags().StringSliceVar(&ignoreControllerKind, "ignore-controller-kind", []string{}, "Comma delimited list of controller kinds to ignore from automatic VPA creation.")
 }
 
 var controllerCmd = &cobra.Command{

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -38,7 +38,7 @@ func init() {
 	controllerCmd.PersistentFlags().BoolVar(&dryRun, "dry-run", false, "If true, don't mutate resources, just list what would have been created.")
 	controllerCmd.PersistentFlags().StringSliceVar(&includeNamespaces, "include-namespaces", []string{}, "Comma delimited list of namespaces to include from recommendations.")
 	controllerCmd.PersistentFlags().StringSliceVar(&excludeNamespaces, "exclude-namespaces", []string{}, "Comma delimited list of namespaces to exclude from recommendations.")
-	controllerCmd.PersistentFlags().StringSliceVar(&ignoreControllerKind, "ignore-controller-kind", []string{}, "Comma delimited list of controller kinds to ignore from automatic VPA creation.")
+	controllerCmd.PersistentFlags().StringSliceVar(&ignoreControllerKind, "ignore-controller-kind", []string{}, "Comma delimited list of controller kinds to exclude from recommendations.")
 }
 
 var controllerCmd = &cobra.Command{

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -50,6 +50,7 @@ var controllerCmd = &cobra.Command{
 		vpaReconciler.OnByDefault = onByDefault
 		vpaReconciler.IncludeNamespaces = includeNamespaces
 		vpaReconciler.ExcludeNamespaces = excludeNamespaces
+		vpaReconciler.IgnoreControllerKind = ignoreControllerKind
 
 		klog.V(4).Infof("Starting controller with Reconciler: %+v", vpaReconciler)
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -56,6 +56,7 @@ You can set the default behavior for VPA creation using some flags. When specifi
 * `--on-by-default` - create VPAs in all namespaces
 * `--include-namespaces` - create VPAs in these namespaces, in addition to any that are labeled
 * `--exclude-namespaces` - when `--on-by-default` is set, exclude this comma-separated list of namespaces
+* `--ignore-controller-kind` - comma-separated list of controller kinds to ignore from automatic VPA creation. For example: `--ignore-controller-kind=Job,CronJob`
 
 #### Enable Namespaces
 

--- a/e2e/tests/20_flags.yaml
+++ b/e2e/tests/20_flags.yaml
@@ -48,3 +48,13 @@ testcases:
     assertions:
     - result.code ShouldEqual 0
     - result.systemout ShouldEqual ""
+- name: Ignore Controller Kind
+  steps:
+  - script: |
+      yq w ../../hack/manifests/controller/deployment.yaml -- spec.template.spec.containers[0].command[2] '--ignore-controller-kind=Deployment' | kubectl -n goldilocks apply -f -
+  - script: kubectl -n goldilocks wait deployment --timeout={{.timeout}} --for condition=available -l app.kubernetes.io/name=goldilocks,app.kubernetes.io/component=controller
+  - script: sleep {{.vpa-wait}}
+  - script: kubectl get verticalpodautoscalers.autoscaling.k8s.io -n demo-excluded -oname
+    assertions:
+    - result.code ShouldEqual 0
+    - result.systemout ShouldEqual ""

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gobuffalo/packr/v2 v2.8.3
 	github.com/google/uuid v1.3.1
 	github.com/gorilla/mux v1.8.0
+	github.com/samber/lo v1.39.0
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.4
@@ -49,6 +50,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
+	golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.12.0 // indirect
 	golang.org/x/sys v0.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -281,6 +281,8 @@ github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
+github.com/samber/lo v1.39.0 h1:4gTz1wUhNYLhFSKl6O+8peW0v2F4BCY034GRpU9WnuA=
+github.com/samber/lo v1.39.0/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
@@ -353,6 +355,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e h1:+WEEuIdZHnUeJJmEUjyYC2gfUMj69yZXw17EnHg/otA=
+golang.org/x/exp v0.0.0-20220722155223-a9213eeb770e/go.mod h1:Kr81I6Kryrl9sr8s2FK3vxD90NdsKWRuOIl2O4CvYbA=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/pkg/vpa/vpa.go
+++ b/pkg/vpa/vpa.go
@@ -159,7 +159,7 @@ func (r Reconciler) namespaceIsManaged(namespace *corev1.Namespace) bool {
 	return r.OnByDefault
 }
 
-func (r Reconciler) reconcileControllersAndVPAs(ns *corev1.Namespace, vpas []vpav1.VerticalPodAutoscaler, controllers []Controller, ignoreControllerKind []string) error {
+func (r Reconciler) reconcileControllersAndVPAs(ns *corev1.Namespace, vpas []vpav1.VerticalPodAutoscaler, controllers []Controller) error {
 	defaultUpdateMode, _ := vpaUpdateModeForResource(ns)
 	defaultResourcePolicy, _ := vpaResourcePolicyForResource(ns)
 	defaultMinReplicas, _ := vpaMinReplicasForResource(ns)

--- a/pkg/vpa/vpa.go
+++ b/pkg/vpa/vpa.go
@@ -112,7 +112,7 @@ func (r Reconciler) ReconcileNamespace(namespace *corev1.Namespace) error {
 		return err
 	}
 
-	return r.reconcileControllersAndVPAs(namespace, vpas, controllers, r.ignoreControllerKind)
+	return r.reconcileControllersAndVPAs(namespace, vpas, controllers)
 }
 
 func (r Reconciler) cleanUpManagedVPAsInNamespace(namespace string, vpas []vpav1.VerticalPodAutoscaler) error {

--- a/pkg/vpa/vpa.go
+++ b/pkg/vpa/vpa.go
@@ -52,7 +52,7 @@ type Reconciler struct {
 	DryRun                bool
 	IncludeNamespaces     []string
 	ExcludeNamespaces     []string
-	ignoreControllerKind  []string
+	IgnoreControllerKind  []string
 }
 
 type Controller struct {

--- a/pkg/vpa/vpa.go
+++ b/pkg/vpa/vpa.go
@@ -24,6 +24,7 @@ import (
 
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2/klogr"
+	"github.com/samber/lo"
 
 	autoscaling "k8s.io/api/autoscaling/v1"
 
@@ -167,7 +168,7 @@ func (r Reconciler) reconcileControllersAndVPAs(ns *corev1.Namespace, vpas []vpa
 	vpaHasAssociatedController := map[string]bool{}
 	for _, controller := range controllers {
 		// Check if the controller kind is in the ignore list
-		if contains(ignoreControllerKind, controller.Kind) {
+		if lo.Contains(ignoreControllerKind, controller.Kind) {
 			continue
 		}
 
@@ -206,16 +207,6 @@ func (r Reconciler) reconcileControllersAndVPAs(ns *corev1.Namespace, vpas []vpa
 	}
 
 	return nil
-}
-
-// Helper function to check if a string is in a slice, used for checking if a controller kind is in the ignore list
-func contains(slice []string, item string) bool {
-	for _, a := range slice {
-		if a == item {
-			return true
-		}
-	}
-	return false
 }
 
 func (r Reconciler) reconcileControllerAndVPA(ns *corev1.Namespace, controller Controller, vpa *vpav1.VerticalPodAutoscaler, vpaUpdateMode *vpav1.UpdateMode, vpaResourcePolicy *vpav1.PodResourcePolicy, minReplicas *int32) error {

--- a/pkg/vpa/vpa.go
+++ b/pkg/vpa/vpa.go
@@ -168,7 +168,7 @@ func (r Reconciler) reconcileControllersAndVPAs(ns *corev1.Namespace, vpas []vpa
 	vpaHasAssociatedController := map[string]bool{}
 	for _, controller := range controllers {
 		// Check if the controller kind is in the ignore list
-		if lo.Contains(ignoreControllerKind, controller.Kind) {
+		if lo.Contains(r.IgnoreControllerKind, controller.Kind) {
 			continue
 		}
 


### PR DESCRIPTION
This PR fixes https://github.com/FairwindsOps/goldilocks/issues/534 

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### prevent VPA creation for Cronjob or Job controller kinds

### What changes did you make?
adding a new arg `--ignore-controller-kind=Job,CronJob` that prevents certain controller kinds from being considered

### What alternative solution should we consider, if any?

## notes
I am sorry that I am not following your contribution guidelines. I am not a developer and was using GitHub Copilot to make these changes. The `make tidy` and `make build` are compiling without any errors - I have only limited resources and permissions on my works laptop. I would be grateful if you would still consider this improvement.