### PR TITLE
Fixing BasePath for loading static assets and routing when a URL doesn't have a forward slash suffix

### DIFF
--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -75,5 +75,9 @@ func validateBasePath(path string) string {
 		path = "/" + path
 	}
 
+	if !strings.HasSuffix(path, "/") {
+		path = path + "/"
+	}
+
 	return path
 }

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -75,5 +75,5 @@ func validateBasePath(path string) string {
 		path = "/" + path
 	}
 
-	return strings.TrimSuffix(path, "/")
+	return path
 }

--- a/pkg/dashboard/router.go
+++ b/pkg/dashboard/router.go
@@ -50,8 +50,7 @@ func GetRouter(setters ...Option) *mux.Router {
 		setter(opts)
 	}
 
-	router := mux.NewRouter().PathPrefix(opts.BasePath).Subrouter()
-
+	router := mux.NewRouter().PathPrefix(opts.BasePath).Subrouter().StrictSlash(false)
 	// health
 	router.Handle("/health", Health("OK"))
 	router.Handle("/healthz", Healthz())

--- a/pkg/dashboard/router.go
+++ b/pkg/dashboard/router.go
@@ -76,7 +76,7 @@ func GetRouter(setters ...Option) *mux.Router {
 			klog.Infof("404: %s", r.URL.Path)
 			http.NotFound(w, r)
 			return
-			}
+		}
 
 		klog.Infof("redirecting to %v", path.Join(opts.BasePath, "/namespaces"))
 		// default redirect on root path

--- a/pkg/dashboard/templates/cost_settings.gohtml
+++ b/pkg/dashboard/templates/cost_settings.gohtml
@@ -13,7 +13,7 @@
           <div class="cost-settings-box__select-container">
             <select name="cloud-providers" id="cost-settings-box__cloud-providers">
             </select>
-            <img src="/static/images/triangle.svg" alt="Select Icon" aria-hidden="true" />
+            <img src="static/images/triangle.svg" alt="Select Icon" aria-hidden="true" />
           </div>
         </div>
         <div class="cost-settings-box__instance-types">
@@ -21,7 +21,7 @@
           <div class="cost-settings-box__select-container">
             <select name="instance-types" id="cost-settings-box__instance-types">
             </select> 
-            <img src="/static/images/triangle.svg" alt="Select Icon" aria-hidden="true" />
+            <img src="static/images/triangle.svg" alt="Select Icon" aria-hidden="true" />
           </div>
         </div>
       </div>

--- a/pkg/dashboard/templates/footer.gohtml
+++ b/pkg/dashboard/templates/footer.gohtml
@@ -5,21 +5,21 @@
   </div>
   <div class="footer__middle">
    <a href="https://github.com/FairwindsOps">
-     <img src="/static/images/github.svg" alt="Github" />
+     <img src="static/images/github.svg" alt="Github" />
    </a>
    <a href="https://twitter.com/fairwindsops">
-     <img src="/static/images/twitter.svg" alt="Twitter" />
+     <img src="static/images/twitter.svg" alt="Twitter" />
    </a>
    <a href="https://join.slack.com/t/fairwindscommunity/shared_invite/zt-e3c6vj4l-3lIH6dvKqzWII5fSSFDi1g">
-     <img src="/static/images/slack.svg" alt="Slack" />
+     <img src="static/images/slack.svg" alt="Slack" />
    </a>
    <a href="https://www.fairwinds.com/fairwinds-newsletter">
-     <img src="/static/images/email.svg" alt="Email" />
+     <img src="static/images/email.svg" alt="Email" />
    </a>
   </div>
   <div class="footer__logo">
     <a href="https://fairwinds.com">
-      <img src="/static/images/fairwinds-logo.svg" alt="Fairwinds Logo" />
+      <img src="static/images/fairwinds-logo.svg" alt="Fairwinds Logo" />
     </a>
   </div>
   <div class="footer__bottom">


### PR DESCRIPTION
This PR fixes #652

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
- Fixing basePath for loading static assets
- Fixing basePath for routing when the URL doesn't end in a `/`. This bug is mentioned in [this pull request comment](https://github.com/FairwindsOps/goldilocks/pull/471#issuecomment-1170408310)

Before this Pull Request static assets such as CSS and images don't load properly if the BasePath is set to anything other than the default. Additionally, the redirecting to the namespace URL doesn't happen if the BasePath is set and accessed via the URL without the forward slash suffix (e.g., a basePath of `example.com/foo` won't redirect to `example.com/foo/namespaces`, but `example.com/foo/` will).

### What changes did you make?

- To fix basePath for loading static assets (without these changes the head's `<base href>` tag is ignored which causes the bug)
    - Modified html templates to refer to static resources without the `/` prefix
    - Added suffix of `/` to the URL path in validateBasePath() in dashboard.go
- In router.go I fixed the routing bug for basePaths without a forward slash at the end:
    - Moved functionality of router handling for the root URL in router.go to its own function rootHander()
    - Moved opts variable declaration to be a class-wide variable
    - Trimmed the `/` suffix from the PathPrefix when building the router in router.go
    - Added a router handler for "" to use the new rootHandler() method. This with the previous change enabled handling of root URLs without a forward slash
    - Removed from rootHandler() a check for if the URL.Path matches "/" as this is now redundant due to changes to opts.BasePath to fix the static assets bug
    - Added to rootHandler() a check for if the URL.Path matches the BasePath without its forward slash suffix. This prevents a URL like `example.com/foo` from returning a 404



### What alternative solution should we consider, if any?

It would be ideal not to use TrimSuffix() so often in this solution, however this may require changes to more files and code then I've done today

### Notes

Let me know if there's anything I've missed as I'm happy to make some adjustments