### PR TITLE
add JSON download link

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -164,3 +164,10 @@ Containers can be excluded for individual workloads by applying a label to any o
 Example label:
 
 `kubectl label deployment myapp goldilocks.fairwinds.com/exclude-containers=linkerd-proxy,istio-proxy`
+
+
+## API Usage
+
+Goldilocks has an API endpoint that returns the VPA Summary.
+
+You can access the API at `/api/:namespace`.

--- a/pkg/dashboard/templates/namespace.gohtml
+++ b/pkg/dashboard/templates/namespace.gohtml
@@ -8,11 +8,21 @@
   </h2>
 
   {{ if not .IsOnlyNamespace }}
-  <a
-    class="detailLink --namespace"
-    href="{{ $.BasePath }}dashboard/{{ $.Namespace }}"
-  >Limit results to the {{ $.Namespace }} namespace</a>
+  <div>
+    <a
+      class="detailLink --namespace"
+      href="{{ $.BasePath }}dashboard/{{ $.Namespace }}"
+    >Limit results to the {{ $.Namespace }} namespace</a>
+  </div>
   {{ end }}
+
+  <div>
+    <a
+      class="detailLink --namespace"
+      href="{{ $.BasePath }}api/{{ $.Namespace }}"
+      target="_blank"
+    >Get summary in JSON</a>
+  </div>
 
   <details open>
     <summary>Workloads</summary>


### PR DESCRIPTION
This PR fixes #

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

Thank you to the maintainers of this great OSS.

`/api/:namespace` added in the PR below is very useful, but is not exposed to users.
I felt that introducing it through a dashboard and documentation would make it easier to utilize.
ref: https://github.com/FairwindsOps/goldilocks/pull/586

<img width="605" alt="image" src="https://github.com/FairwindsOps/goldilocks/assets/20282867/be86a125-1fc5-4443-a7e0-8d1db203f3c7">

### What changes did you make?

- Added a link to `/api/:namespace` in the dashboard.
- Added API description to the documentation.

### What alternative solution should we consider, if any?

`goldilocks summary` is useful, but requires users to download the CLI themselves.

If `/api/` is an internal feature, this may not be a good change.
