### PR TITLE
Added option to use VpaMinReplicasAnnotation from labels

### DIFF
--- a/pkg/vpa/vpa.go
+++ b/pkg/vpa/vpa.go
@@ -411,6 +411,8 @@ func vpaResourcePolicyForResource(obj runtime.Object) (*vpav1.PodResourcePolicy,
 	accessor, _ := meta.Accessor(obj)
 	if val, ok := accessor.GetAnnotations()[utils.VpaResourcePolicyAnnotation]; ok {
 		resourcePolicyStr = val
+	} else if val, ok := accessor.GetLabels()[utils.VpaResourcePolicyAnnotation]; ok {
+		resourcePolicyStr = val
 	}
 
 	if resourcePolicyStr == "" {

--- a/pkg/vpa/vpa.go
+++ b/pkg/vpa/vpa.go
@@ -436,6 +436,8 @@ func vpaMinReplicasForResource(obj runtime.Object) (*int32, bool) {
 	accessor, _ := meta.Accessor(obj)
 	if val, ok := accessor.GetAnnotations()[utils.VpaMinReplicasAnnotation]; ok {
 		minReplicasString = val
+	} else if val, ok := accessor.GetLabels()[utils.VpaMinReplicasAnnotation]; ok {
+		minReplicasString = val
 	}
 
 	if minReplicasString == "" {


### PR DESCRIPTION

This PR adds the option of using `goldilocks.fairwinds.com/vpa-min-replicas: X` as a label.

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description

Currently it is not possible to set vpa-min-relplicas with labels, like it is with some of the other options. This fix should ensure that is also the case for `vpa-min-replicas`

### What's the goal of this PR?

To support labels for `vpa-min-replicas`

### What changes did you make?

I added an if/else statement in the code where this was needed. The solution was inspired by how this is implemented other places in the code. Feel free to change it to your liking!

### What alternative solution should we consider, if any?

blank

