### PR TITLE
Allow the manual setting of recommenders on VPAs (not overwritten by the goldilocks controller) and a namespace label to add a custom recommender

### DIFF
--- a/pkg/vpa/vpa.go
+++ b/pkg/vpa/vpa.go
@@ -22,9 +22,9 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/samber/lo"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2/klogr"
-	"github.com/samber/lo"
 
 	autoscaling "k8s.io/api/autoscaling/v1"
 
@@ -221,7 +221,26 @@ func (r Reconciler) reconcileControllerAndVPA(ns *corev1.Namespace, controller C
 		klog.V(5).Infof("%s/%s has custom vpa-resource-policy", controller.Kind, controller.Name)
 	}
 
+	// Fetch the recommender name from the namespace label
+	recommenderName, err := vpaRecommenderNameForNamespace(ns)
+	if err != nil {
+		klog.Errorf("Error parsing recommender name for Namespace/%s: %v", ns.Name, err)
+		return err
+	}
+
 	desiredVPA := r.getVPAObject(vpa, ns, controller, vpaUpdateMode, vpaResourcePolicy, minReplicas)
+
+	// Set the recommender if recommenderName is not empty
+	if recommenderName != "" {
+		desiredVPA.Spec.Recommenders = []*vpav1.VerticalPodAutoscalerRecommenderSelector{
+			{
+				Name: recommenderName,
+			},
+		}
+	} else if vpa != nil {
+		// Preserve existing recommenders if any
+		desiredVPA.Spec.Recommenders = vpa.Spec.Recommenders
+	}
 
 	if vpa == nil {
 		klog.V(5).Infof("%s/%s does not have a VPA currently, creating VPA/%s", controller.Kind, controller.Name, controller.Name)
@@ -348,6 +367,7 @@ func (r Reconciler) getVPAObject(existingVPA *vpav1.VerticalPodAutoscaler, ns *c
 				Name:      "goldilocks-" + controller.Name,
 				Namespace: ns.Name,
 			},
+			Spec: vpav1.VerticalPodAutoscalerSpec{},
 		}
 	} else {
 		// or use the existing VPA as a template to update from
@@ -357,25 +377,32 @@ func (r Reconciler) getVPAObject(existingVPA *vpav1.VerticalPodAutoscaler, ns *c
 	// update the labels on the VPA
 	desiredVPA.Labels = utils.VPALabels
 
-	// update the spec on the VPA
-	desiredVPA.Spec = vpav1.VerticalPodAutoscalerSpec{
-		TargetRef: &autoscaling.CrossVersionObjectReference{
-			APIVersion: controller.APIVersion,
-			Kind:       controller.Kind,
-			Name:       controller.Name,
-		},
-		UpdatePolicy: &vpav1.PodUpdatePolicy{
-			UpdateMode: updateMode,
-		},
-		ResourcePolicy: resourcePolicy,
+	// Update or set the managed fields in Spec
+	if desiredVPA.Spec.TargetRef == nil {
+		desiredVPA.Spec.TargetRef = &autoscaling.CrossVersionObjectReference{}
+	}
+	desiredVPA.Spec.TargetRef.APIVersion = controller.APIVersion
+	desiredVPA.Spec.TargetRef.Kind = controller.Kind
+	desiredVPA.Spec.TargetRef.Name = controller.Name
+
+	if desiredVPA.Spec.UpdatePolicy == nil {
+		desiredVPA.Spec.UpdatePolicy = &vpav1.PodUpdatePolicy{}
+	}
+	desiredVPA.Spec.UpdatePolicy.UpdateMode = updateMode
+
+	if resourcePolicy != nil {
+		desiredVPA.Spec.ResourcePolicy = resourcePolicy
+	} else if existingVPA != nil {
+		// Preserve existing ResourcePolicy if not overridden
+		desiredVPA.Spec.ResourcePolicy = existingVPA.Spec.ResourcePolicy
 	}
 
-	if minReplicas != nil {
-		if *minReplicas > 0 {
-			desiredVPA.Spec.UpdatePolicy.MinReplicas = minReplicas
-		}
-
+	if minReplicas != nil && *minReplicas > 0 {
+		desiredVPA.Spec.UpdatePolicy.MinReplicas = minReplicas
 	}
+
+	// No change to desiredVPA.Spec.Recommenders
+	// It will be preserved from existingVPA if present
 
 	return desiredVPA
 }
@@ -456,4 +483,12 @@ func vpaMinReplicasForResource(obj runtime.Object) (*int32, bool) {
 	minReplicasInt32 := int32(minReplicas)
 
 	return &minReplicasInt32, explicit
+}
+
+func vpaRecommenderNameForNamespace(ns *corev1.Namespace) (string, error) {
+	recommenderName, ok := ns.Labels["goldilocks.fairwinds.com/vpa-recommenders"]
+	if !ok || recommenderName == "" {
+		return "", nil
+	}
+	return recommenderName, nil
 }

--- a/pkg/vpa/vpa_test.go
+++ b/pkg/vpa/vpa_test.go
@@ -16,6 +16,7 @@ package vpa
 
 import (
 	"context"
+	autoscaling "k8s.io/api/autoscaling/v1"
 	"strings"
 	"testing"
 
@@ -308,6 +309,54 @@ func Test_updateVPA(t *testing.T) {
 	assert.NotEqual(t, &testVPA, currVPA)
 	// check that the update mode changed
 	assert.Equal(t, updateModeAuto, *currVPA.Spec.UpdatePolicy.UpdateMode)
+}
+
+func Test_updateVPAWithRecommenders(t *testing.T) {
+	setupVPAForTests(t)
+	VPAClient := GetInstance().VPAClient
+
+	// First test the dryrun
+	rec := GetInstance()
+	rec.DryRun = true
+
+	testNS := nsTesting.DeepCopy()
+	testNS.Labels["goldilocks.fairwinds.com/vpa-update-mode"] = "off"
+
+	controller := Controller{
+		APIVersion:   "apps/v1",
+		Kind:         "Deployment",
+		Name:         "test-vpa",
+		Unstructured: nil,
+	}
+	updateMode, _ := vpaUpdateModeForResource(testNS)
+	resourcePolicy, _ := vpaResourcePolicyForResource(testNS)
+	minReplicas, _ := vpaMinReplicasForResource(testNS)
+	testVPA := rec.getVPAObject(nil, testNS, controller, updateMode, resourcePolicy, minReplicas)
+
+	// Add custom Recommenders to the VPA
+	testVPA.Spec.Recommenders = []*vpav1.VerticalPodAutoscalerRecommenderSelector{
+		{
+			Name: "my-custom-recommender",
+		},
+	}
+
+	_, err := VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(testNS.Name).Create(context.TODO(), &testVPA, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// Dry run update
+	errUpdateDryRun := rec.updateVPA(testVPA)
+	assert.NoError(t, errUpdateDryRun)
+	currVPA, _ := VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(testNS.Name).Get(context.TODO(), "goldilocks-test-vpa", metav1.GetOptions{})
+	assert.EqualValues(t, &testVPA, currVPA)
+
+	// Live update
+	rec.DryRun = false
+	errUpdate := rec.updateVPA(testVPA)
+	assert.NoError(t, errUpdate)
+	currVPA, _ = VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(testNS.Name).Get(context.TODO(), "goldilocks-test-vpa", metav1.GetOptions{})
+
+	// Assert that the Recommenders field is preserved
+	assert.Equal(t, testVPA.Spec.Recommenders, currVPA.Spec.Recommenders, "Recommenders field should be preserved after update")
 }
 
 func Test_listVPA(t *testing.T) {
@@ -712,4 +761,111 @@ func Test_ReconcileNamespaceStatefulSet(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(vpaList.Items))
 	assert.Equal(t, "goldilocks-test-sts", vpaList.Items[0].ObjectMeta.Name)
+}
+
+func Test_ReconcileVPAWithCustomRecommenders(t *testing.T) {
+	setupVPAForTests(t)
+	rec := GetInstance()
+	VPAClient := rec.VPAClient
+	DynamicClient := rec.DynamicClient.Client
+
+	// Use the existing namespace nsLabeledTrue and its unstructured version
+	nsName := nsLabeledTrue.ObjectMeta.Name
+	nsUnstructured := nsLabeledTrueUnstructured
+
+	// Create the namespace in the dynamic client
+	_, err := DynamicClient.Resource(schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "namespaces",
+	}).Create(context.TODO(), nsUnstructured, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// Create a deployment in the namespace
+	deploymentName := "test-deployment"
+	testDeployment := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      deploymentName,
+				"namespace": nsName,
+			},
+			"spec": map[string]interface{}{
+				"replicas": int64(1),
+				"selector": map[string]interface{}{
+					"matchLabels": map[string]interface{}{
+						"app": "test",
+					},
+				},
+				"template": map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"app": "test",
+						},
+					},
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "test-container",
+								"image": "nginx",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Create the deployment in the dynamic client
+	_, err = DynamicClient.Resource(schema.GroupVersionResource{
+		Group:    "apps",
+		Version:  "v1",
+		Resource: "deployments",
+	}).Namespace(nsName).Create(context.TODO(), testDeployment, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// Manually create a VPA with a custom Recommenders field
+	customRecommenders := []*vpav1.VerticalPodAutoscalerRecommenderSelector{
+		{
+			Name: "my-custom-recommender",
+		},
+	}
+	vpaName := "goldilocks-" + deploymentName
+	updateModeOff := vpav1.UpdateModeOff
+	initialVPA := &vpav1.VerticalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vpaName,
+			Namespace: nsName,
+			Labels:    utils.VPALabels,
+		},
+		Spec: vpav1.VerticalPodAutoscalerSpec{
+			TargetRef: &autoscaling.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       deploymentName,
+			},
+			UpdatePolicy: &vpav1.PodUpdatePolicy{
+				UpdateMode: &updateModeOff,
+			},
+			Recommenders: customRecommenders,
+		},
+	}
+
+	// Create the VPA using the VPA client
+	_, err = VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(nsName).
+		Create(context.TODO(), initialVPA, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// Run the reconciliation process
+	err = rec.ReconcileNamespace(&nsLabeledTrue)
+	assert.NoError(t, err)
+
+	// Retrieve the VPA after reconciliation
+	reconciledVPA, err := VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(nsName).
+		Get(context.TODO(), vpaName, metav1.GetOptions{})
+	assert.NoError(t, err)
+
+	// Assert that the Recommenders field is preserved
+	assert.Equal(t, initialVPA.Spec.Recommenders, reconciledVPA.Spec.Recommenders, "Recommenders field should be preserved after reconciliation")
 }


### PR DESCRIPTION
## Checklist
* [X] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
To allow recommenders to be set on VPAs without being overwritten and provide a label that can be used to have goldilocks manage the setting of a given custom recommender

### What changes did you make?
The spec is no longer always overwritten by the goldilocks controller, but rather it is additive when not explicitly a goldilocks managed field

### What alternative solution should we consider, if any?
1. The label can be the ONLY way to set a custom recommender if using goldilocks
2. No label can be provided by goldilocks, but allow recommenders to be added and not overwritten still
