### PR TITLE
Allow a custom recommender to be set via annotation or label on the namespace

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -126,6 +126,11 @@ Example of an annotation
       "memory": "2048Mi" } }, { "containerName": "istio-proxy", "mode": "Off" }
       ] }
 ```
+#### VPA Custom Recommender
+
+If you want a specific namespace to use a custom VPA recommender,
+then you can label the workload with `goldilocks.fairwinds.com/vpa-recommenders=<recommender-name>`
+to add a recommender to the VPA specs for that namespace.
 
 #### Workload Specifications
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -129,7 +129,7 @@ Example of an annotation
 #### VPA Custom Recommender
 
 If you want a specific namespace to use a custom VPA recommender,
-then you can label the workload with `goldilocks.fairwinds.com/vpa-recommenders=<recommender-name>`
+then you can label or annotate the workload with `goldilocks.fairwinds.com/vpa-recommenders=<recommender-name>`
 to add a recommender to the VPA specs for that namespace.
 
 #### Workload Specifications

--- a/pkg/vpa/vpa.go
+++ b/pkg/vpa/vpa.go
@@ -22,8 +22,8 @@ import (
 	"strconv"
 	"strings"
 
-	"k8s.io/client-go/util/retry"
 	"github.com/samber/lo"
+	"k8s.io/client-go/util/retry"
 
 	autoscaling "k8s.io/api/autoscaling/v1"
 

--- a/pkg/vpa/vpa_test.go
+++ b/pkg/vpa/vpa_test.go
@@ -16,6 +16,7 @@ package vpa
 
 import (
 	"context"
+	autoscaling "k8s.io/api/autoscaling/v1"
 	"strings"
 	"testing"
 
@@ -308,6 +309,54 @@ func Test_updateVPA(t *testing.T) {
 	assert.NotEqual(t, &testVPA, currVPA)
 	// check that the update mode changed
 	assert.Equal(t, updateModeAuto, *currVPA.Spec.UpdatePolicy.UpdateMode)
+}
+
+func Test_updateVPAWithRecommenders(t *testing.T) {
+	setupVPAForTests(t)
+	VPAClient := GetInstance().VPAClient
+
+	// First test the dryrun
+	rec := GetInstance()
+	rec.DryRun = true
+
+	testNS := nsTesting.DeepCopy()
+	testNS.Labels["goldilocks.fairwinds.com/vpa-update-mode"] = "off"
+
+	controller := Controller{
+		APIVersion:   "apps/v1",
+		Kind:         "Deployment",
+		Name:         "test-vpa",
+		Unstructured: nil,
+	}
+	updateMode, _ := vpaUpdateModeForResource(testNS)
+	resourcePolicy, _ := vpaResourcePolicyForResource(testNS)
+	minReplicas, _ := vpaMinReplicasForResource(testNS)
+	testVPA := rec.getVPAObject(nil, testNS, controller, updateMode, resourcePolicy, minReplicas)
+
+	// Add custom Recommenders to the VPA
+	testVPA.Spec.Recommenders = []*vpav1.VerticalPodAutoscalerRecommenderSelector{
+		{
+			Name: "my-custom-recommender",
+		},
+	}
+
+	_, err := VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(testNS.Name).Create(context.TODO(), &testVPA, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// Dry run update
+	errUpdateDryRun := rec.updateVPA(testVPA)
+	assert.NoError(t, errUpdateDryRun)
+	currVPA, _ := VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(testNS.Name).Get(context.TODO(), "goldilocks-test-vpa", metav1.GetOptions{})
+	assert.EqualValues(t, &testVPA, currVPA)
+
+	// Live update
+	rec.DryRun = false
+	errUpdate := rec.updateVPA(testVPA)
+	assert.NoError(t, errUpdate)
+	currVPA, _ = VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(testNS.Name).Get(context.TODO(), "goldilocks-test-vpa", metav1.GetOptions{})
+
+	// Assert that the Recommenders field is preserved
+	assert.Equal(t, testVPA.Spec.Recommenders, currVPA.Spec.Recommenders, "Recommenders field should be preserved after update")
 }
 
 func Test_listVPA(t *testing.T) {
@@ -712,4 +761,111 @@ func Test_ReconcileNamespaceStatefulSet(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(vpaList.Items))
 	assert.Equal(t, "goldilocks-test-sts", vpaList.Items[0].ObjectMeta.Name)
+}
+
+func Test_ReconcileVPAWithCustomRecommenders(t *testing.T) {
+	setupVPAForTests(t)
+	rec := GetInstance()
+	VPAClient := rec.VPAClient
+	DynamicClient := rec.DynamicClient.Client
+
+	// Use the existing namespace nsLabeledTrue and its unstructured version
+	nsName := nsLabeledTrue.ObjectMeta.Name
+	nsUnstructured := nsLabeledTrueUnstructured
+
+	// Create the namespace in the dynamic client
+	_, err := DynamicClient.Resource(schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "namespaces",
+	}).Create(context.TODO(), nsUnstructured, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// Create a deployment in the namespace
+	deploymentName := "test-deployment"
+	testDeployment := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      deploymentName,
+				"namespace": nsName,
+			},
+			"spec": map[string]interface{}{
+				"replicas": int64(1),
+				"selector": map[string]interface{}{
+					"matchLabels": map[string]interface{}{
+						"app": "test",
+					},
+				},
+				"template": map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"labels": map[string]interface{}{
+							"app": "test",
+						},
+					},
+					"spec": map[string]interface{}{
+						"containers": []interface{}{
+							map[string]interface{}{
+								"name":  "test-container",
+								"image": "nginx",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Create the deployment in the dynamic client
+	_, err = DynamicClient.Resource(schema.GroupVersionResource{
+		Group:    "apps",
+		Version:  "v1",
+		Resource: "deployments",
+	}).Namespace(nsName).Create(context.TODO(), testDeployment, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// Manually create a VPA with a custom Recommenders field
+	customRecommenders := []*vpav1.VerticalPodAutoscalerRecommenderSelector{
+		{
+			Name: "my-custom-recommender",
+		},
+	}
+	vpaName := "goldilocks-" + deploymentName
+	updateModeOff := vpav1.UpdateModeOff
+	initialVPA := &vpav1.VerticalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      vpaName,
+			Namespace: nsName,
+			Labels:    utils.VPALabels,
+		},
+		Spec: vpav1.VerticalPodAutoscalerSpec{
+			TargetRef: &autoscaling.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       deploymentName,
+			},
+			UpdatePolicy: &vpav1.PodUpdatePolicy{
+				UpdateMode: &updateModeOff,
+			},
+			Recommenders: customRecommenders,
+		},
+	}
+
+	// Create the VPA using the VPA client
+	_, err = VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(nsName).
+		Create(context.TODO(), initialVPA, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// Run the reconciliation process
+	err = rec.ReconcileNamespace(&nsLabeledTrue)
+	assert.NoError(t, err)
+
+	// Retrieve the VPA after reconciliation
+	reconciledVPA, err := VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(nsName).
+		Get(context.TODO(), vpaName, metav1.GetOptions{})
+	assert.NoError(t, err)
+
+	// Assert that the Recommenders field is preserved
+	assert.Equal(t, initialVPA.Spec.Recommenders, reconciledVPA.Spec.Recommenders, "Recommenders field should be preserved after reconciliation")
 }


### PR DESCRIPTION
## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
What's the goal of this PR?
To allow recommenders to be set on VPAs without being overwritten and provide a label that can be used to have goldilocks manage the setting of a given custom recommender

What changes did you make?
The spec is no longer always overwritten by the goldilocks controller, but rather it is additive when not explicitly a goldilocks managed field

What alternative solution should we consider, if any?
The label can be the ONLY way to set a custom recommender if using goldilocks
No label can be provided by goldilocks, but allow recommenders to be added and not overwritten still