### PR TITLE
Change default `onDelete` and `OnUpdate` log level to debug

### DIFF
--- a/pkg/handler/handler.go
+++ b/pkg/handler/handler.go
@@ -38,7 +38,7 @@ func OnUpdate(obj interface{}, event utils.Event) {
 	case *corev1.Namespace:
 		OnNamespaceChanged(obj.(*corev1.Namespace), event)
 	default:
-		klog.Errorf("Object has unknown type of %T", t)
+		klog.V(2).Infof("Object has unknown type of %T", t)
 	}
 }
 
@@ -50,6 +50,6 @@ func onDelete(event utils.Event) {
 	case "pod":
 		OnPodChanged(&corev1.Pod{}, event)
 	default:
-		klog.Errorf("object has unknown resource type %s", event.ResourceType)
+		klog.V(2).Infof("object has unknown resource type %s", event.ResourceType)
 	}
 }


### PR DESCRIPTION
This PR fixes https://github.com/FairwindsOps/goldilocks/issues/799

## Checklist
* [X] I have signed the CLA
* [X] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?

The main goal is to reduce unnecessary error-level logging for expected but non-critical conditions in the event handlers. Currently, when `OnUpdate` or `onDelete` receive an unexpected object type or resource type, they log at the error level, which are not necessarily errors.

By lowering the log level, we make logs less noisy and avoid false alarms in monitoring systems that watch for error-level logs.

### What changes did you make?

Changed log statements for unknown object types in `OnUpdate` from `klog.Errorf` to `klog.V(2).Infof`.
Changed log statements for unknown resource types in `onDelete` from `klog.Errorf` to `klog.V(2).Infof`.
These log messages are now classified as verbose info logs instead of errors, reflecting their actual severity.