### PR TITLE
fix: correct memory unit formatting in dashboard

### DIFF
--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -115,9 +115,33 @@ var testFormatResourceCases = []struct {
 	{
 		description: "Memory in too large of units",
 		testData: v1.ResourceList{
-			"memory": resource.MustParse("123456k"),
+			"memory": resource.MustParse("123456Ki"),
 		},
 		resourceType: "memory",
-		expected:     "124M",
+		expected:     "121Mi",
 	},
+	{
+		description: "Round up complex byte values to Mi",
+		testData: v1.ResourceList{
+			"memory": resource.MustParse("1038683533"),
+		},
+		resourceType: "memory",
+		expected:     "991Mi",
+	},
+    {
+        description: "Normalize Decimal G to Binary Mi",
+        testData:    v1.ResourceList{
+            v1.ResourceMemory: resource.MustParse("1G"),
+        },
+		resourceType: "memory",
+        expected: "954Mi",
+    },
+    {
+        description: "Normalize Decimal k to Binary Ki",
+        testData: v1.ResourceList{
+            v1.ResourceMemory: resource.MustParse("100k"),
+        },
+        resourceType: "memory",
+        expected: "98Ki",
+    },
 }


### PR DESCRIPTION
This PR fixes #522 & #728 

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
This PR improves the `FormatResourceList` function to handle memory unit conversion more accurately.   

The previous implementation attempted to shorten strings by forcing conversions to Decimal scales (Kilo, Mega, Giga - Base 10), whereas Kubernetes memory is standardly represented in BinarySI (Ki, Mi, Gi - Base 2). This led to confusing displays (e.g., `1.05G` instead of `1024Mi`) and potential precision loss due to the `RoundUp` method.

Additionally, raw byte values from VPA recommendations (e.g., `104857600`) were sometimes displayed as raw bytes instead of human-readable units.

### What changes did you make?
The logic has been updated to:
1.  Force `BinarySI` formatting (Ki, Mi, Gi).
2.  Smartly round values:
    * Small values (< 1Mi) are rounded to the nearest **Ki**.
    * Standard values (>= 1Mi) are rounded to the nearest **Mi**.
3.  Ensure `Set()` is called to refresh the string representation even for existing round numbers.

Fixes #522
Fixes #728
