### PR TITLE
Do not panic on a VPA that has no targetRef

### DIFF
--- a/pkg/summary/constants_test.go
+++ b/pkg/summary/constants_test.go
@@ -392,8 +392,7 @@ var testSummaryDaemonSet = Summary{
 	},
 }
 
-// A VPA whose spec omits targetRef, which the VPA CRD allows
-
+// testVPANoTargetRef is a VPA whose spec omits targetRef, which the VPA CRD allows
 var testVPANoTargetRef = &vpav1.VerticalPodAutoscaler{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "test-vpa-no-target-ref",

--- a/pkg/summary/constants_test.go
+++ b/pkg/summary/constants_test.go
@@ -391,3 +391,18 @@ var testSummaryDaemonSet = Summary{
 		},
 	},
 }
+
+// A VPA whose spec omits targetRef, which the VPA CRD allows
+
+var testVPANoTargetRef = &vpav1.VerticalPodAutoscaler{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "test-vpa-no-target-ref",
+		Labels:    utils.VPALabels,
+		Namespace: "testing",
+	},
+	Spec: vpav1.VerticalPodAutoscalerSpec{
+		UpdatePolicy: &vpav1.PodUpdatePolicy{
+			UpdateMode: &updateMode,
+		},
+	},
+}

--- a/pkg/summary/summary.go
+++ b/pkg/summary/summary.go
@@ -138,6 +138,11 @@ func (s Summarizer) GetSummary() (Summary, error) {
 	for _, vpa := range s.vpas {
 		klog.V(8).Infof("Analyzing vpa: %v", vpa.Name)
 
+		if vpa.Spec.TargetRef == nil {
+			klog.Errorf("no targetRef on VPA/%s", vpa.Name)
+			continue
+		}
+
 		// get or create the namespaceSummary for this VPA's namespace
 		namespace := vpa.Namespace
 		var nsSummary namespaceSummary
@@ -324,6 +329,10 @@ func (s *Summarizer) updateWorkloads() error {
 
 // vpaMatchesWorkload returns true if the VPA's target matches the workload
 func vpaMatchesWorkload(v vpav1.VerticalPodAutoscaler, w controllerUtils.Workload) bool {
+	// targetRef is optional in the VPA CRD, and a VPA without one targets nothing
+	if v.Spec.TargetRef == nil {
+		return false
+	}
 	// check if the VPA's target matches the workload's target
 	if v.Spec.TargetRef.Kind != w.TopController.GetKind() {
 		return false

--- a/pkg/summary/summary.go
+++ b/pkg/summary/summary.go
@@ -139,7 +139,7 @@ func (s Summarizer) GetSummary() (Summary, error) {
 		klog.V(8).Infof("Analyzing vpa: %v", vpa.Name)
 
 		if vpa.Spec.TargetRef == nil {
-			klog.Errorf("no targetRef on VPA/%s", vpa.Name)
+			klog.Warningf("no targetRef on VPA/%s", vpa.Name)
 			continue
 		}
 

--- a/pkg/summary/summary_test.go
+++ b/pkg/summary/summary_test.go
@@ -89,3 +89,30 @@ func Test_Summarizer_Daemonset(t *testing.T) {
 
 	assert.EqualValues(t, testSummaryDaemonSet, got)
 }
+
+func Test_Summarizer_VPAWithoutTargetRef(t *testing.T) {
+	kubeClientVPA := kube.GetMockVPAClient()
+	kubeClient := kube.GetMockClient()
+	dynamicClient := kube.GetMockDynamicClient()
+	controllerUtilsClient := kube.GetMockControllerUtilsClient(dynamicClient)
+
+	summarizer := NewSummarizer()
+	summarizer.kubeClient = kubeClient
+	summarizer.vpaClient = kubeClientVPA
+	summarizer.dynamicClient = dynamicClient
+	summarizer.controllerUtilsClient = controllerUtilsClient
+
+	_, err := dynamicClient.Client.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}).Namespace("testing").Create(context.TODO(), testDeploymentBasicUnstructured, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	_, err = dynamicClient.Client.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "replicasets"}).Namespace("testing").Create(context.TODO(), testDeploymentBasicReplicaSetUnstructured, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	_, err = dynamicClient.Client.Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}).Namespace("testing").Create(context.TODO(), testDeploymentBasicPodUnstructured, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	_, err = kubeClientVPA.Client.AutoscalingV1().VerticalPodAutoscalers("testing").Create(context.TODO(), testVPANoTargetRef, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	// a VPA with no targetRef should be skipped, not bring the summary down
+	got, err := summarizer.GetSummary()
+	assert.NoError(t, err)
+	assert.Empty(t, got.Namespaces)
+}


### PR DESCRIPTION
`VerticalPodAutoscalerSpec.TargetRef` is a pointer, and the VPA CRD does not mark it required, so the API server will happily accept a VPA with no `spec.targetRef`. Goldilocks dereferences it in two places without checking:

- `pkg/summary/summary.go:328` in `vpaMatchesWorkload`
- `pkg/summary/summary.go:155` when building the `workloadSummary`

`updateWorkloads` hits the first one, so any `GetSummary` call crashes as soon as one such VPA carries the goldilocks labels. The dashboard handler and the CLI summary both go through `GetSummary`.

Stack from a unit test that creates a labelled VPA with no `targetRef`:

```
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0]
summary.vpaMatchesWorkload(...)
	pkg/summary/summary.go:328
summary.(*Summarizer).updateWorkloads(...)
	pkg/summary/summary.go:315
summary.(*Summarizer).Update(...)
	pkg/summary/summary.go:259
summary.Summarizer.GetSummary(...)
	pkg/summary/summary.go:127
```

A VPA with no target does not point at any workload, so this treats it as matching nothing and logs and skips it in the summary loop, in the same style as the existing "no matching Workloads found for VPA/%s" path just below.

`Test_Summarizer_VPAWithoutTargetRef` is new: it panics on master and passes with the change. `go test ./pkg/...` is green and `gofmt` is clean.