### PR TITLE
Show a badge when a container's requests/limits already match the VPA recommendation

### DIFF
--- a/pkg/dashboard/assets/css/main.css
+++ b/pkg/dashboard/assets/css/main.css
@@ -357,6 +357,15 @@ COMPONENTS
   color: var(--color-text-1);
 }
 
+.badge.--match {
+  align-items: center;
+  background: var(--color-positive);
+  color: var(--color-text-inverse-1);
+  display: inline-flex;
+  gap: var(--gap--2);
+  margin-left: var(--gap--1);
+}
+
 .detailInfo:not(.--qos) {
   --gap-detail: var(--gap-0);
 

--- a/pkg/dashboard/templates/namespace.gohtml
+++ b/pkg/dashboard/templates/namespace.gohtml
@@ -40,6 +40,12 @@
           <h4>
             <span class="badge detailBadge --container">Container</span>
             {{ $cName }}
+            {{ if $cSummary.MatchesRecommendation }}
+            <span class="badge --match" title="Current requests and limits already match the VPA recommendation">
+              <i aria-hidden="true" class="fas fa-check"></i>
+              Matches Recommendation
+            </span>
+            {{ end }}
           </h4>
 
           {{ if opts.EnableCost }}

--- a/pkg/summary/container_summary_test.go
+++ b/pkg/summary/container_summary_test.go
@@ -1,0 +1,137 @@
+// Copyright 2019 FairwindsOps Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package summary
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func Test_ContainerSummary_MatchesRecommendation(t *testing.T) {
+	target := corev1.ResourceList{
+		corev1.ResourceCPU:    resource.MustParse("500m"),
+		corev1.ResourceMemory: resource.MustParse("256Mi"),
+	}
+
+	tests := []struct {
+		name     string
+		requests corev1.ResourceList
+		limits   corev1.ResourceList
+		target   corev1.ResourceList
+		want     bool
+	}{
+		{
+			name: "matches exactly",
+			requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+			limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+			target: target,
+			want:   true,
+		},
+		{
+			name: "matches with different but equivalent representation",
+			requests: corev1.ResourceList{
+				// 0.5 CPU written as whole-unit decimal instead of milli
+				corev1.ResourceCPU:    resource.MustParse("0.5"),
+				corev1.ResourceMemory: resource.MustParse("268435456"), // 256Mi in bytes
+			},
+			limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0.5"),
+				corev1.ResourceMemory: resource.MustParse("268435456"),
+			},
+			target: target,
+			want:   true,
+		},
+		{
+			name: "cpu request differs",
+			requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("250m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+			limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+			target: target,
+			want:   false,
+		},
+		{
+			name: "memory limit differs",
+			requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+			limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+			target: target,
+			want:   false,
+		},
+		{
+			name:     "requests and limits unset",
+			requests: corev1.ResourceList{},
+			limits:   corev1.ResourceList{},
+			target:   target,
+			want:     false,
+		},
+		{
+			name: "requests unset, limits match",
+			requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+			limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("500m"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+			target: target,
+			want:   false,
+		},
+		{
+			name: "unset request against a zero target does not match",
+			requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+			limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+			target: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("0"),
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cs := ContainerSummary{
+				Requests: tt.requests,
+				Limits:   tt.limits,
+				Target:   tt.target,
+			}
+			assert.Equal(t, tt.want, cs.MatchesRecommendation())
+		})
+	}
+}

--- a/pkg/summary/summary.go
+++ b/pkg/summary/summary.go
@@ -20,6 +20,7 @@ import (
 
 	controllerUtils "github.com/fairwindsops/controller-utils/pkg/controller"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
@@ -71,6 +72,42 @@ type ContainerSummary struct {
 	ContainerCostInt  int
 	GuaranteedCostInt int
 	BurstableCostInt  int
+}
+
+// MatchesRecommendation reports whether this container's current CPU/memory
+// requests and limits are already set to exactly what the VPA recommends
+// (its Target). This is intentionally an exact match (via resource.Quantity's
+// Cmp, not naive string/struct equality) on all four values -- CPU request,
+// CPU limit, memory request, and memory limit -- rather than a fuzzy or
+// tolerance-based comparison. A container that matches on every value is
+// already sized the way the VPA would set it, and incidentally already
+// qualifies for the Guaranteed QoS class.
+//
+// A value that is unset (the zero Quantity) never counts as a match, even if
+// the corresponding target recommendation also happens to be zero, since an
+// unset request/limit is meaningfully different from an explicit one.
+func (c ContainerSummary) MatchesRecommendation() bool {
+	cpuTarget := c.Target[corev1.ResourceCPU]
+	memTarget := c.Target[corev1.ResourceMemory]
+
+	return quantityMatchesTarget(c.Requests[corev1.ResourceCPU], cpuTarget) &&
+		quantityMatchesTarget(c.Limits[corev1.ResourceCPU], cpuTarget) &&
+		quantityMatchesTarget(c.Requests[corev1.ResourceMemory], memTarget) &&
+		quantityMatchesTarget(c.Limits[corev1.ResourceMemory], memTarget)
+}
+
+// quantityMatchesTarget returns true if existing is set (non-zero) and is
+// exactly equal to target, as determined by resource.Quantity.Cmp(). Quantity
+// values can be semantically equal despite different internal representations
+// (e.g. "1000m" and "1" both represent one whole CPU, and "1Gi" and
+// "1073741824" both represent the same number of bytes), so Cmp is used
+// rather than reflect.DeepEqual or comparing the formatted strings, either of
+// which would report a false mismatch for values like these.
+func quantityMatchesTarget(existing, target resource.Quantity) bool {
+	if existing.IsZero() {
+		return false
+	}
+	return existing.Cmp(target) == 0
 }
 
 // Summarizer represents a source of generating a summary of VPAs


### PR DESCRIPTION
## Summary

Closes #321.

The original ask on #321 was a toggle to hide workloads whose current requests/limits already match the VPA recommendation. A maintainer (@milanmayr) suggested a smaller iterative step instead:

> What about a default marker that shows that they already match? Or perhaps a different color scheme for the resource? I think it could be a good iterative change without adding a configurable option just yet.

This PR follows that direction: it adds a small "Matches Recommendation" badge next to a container's name in the dashboard when that container is already sized exactly the way the VPA recommends. No new toggle, no configuration option, nothing hidden -- just a visual marker, consistent with the existing badge/icon vocabulary already used on the dashboard (the `--namespace`/`--deployment`/`--container` badges, and the `fa-equals success` icon already used in the Guaranteed QoS comparison table).

## Design decision: what counts as "matches"

A container "matches" its recommendation when **all four** of its current values -- CPU request, CPU limit, memory request, and memory limit -- are **exactly equal** to the VPA's `Target` recommendation:

- Exact equality, not a tolerance/threshold. The dashboard doesn't have a tolerance concept anywhere else, and the issue is explicitly about an iterative step, so this avoids inventing new config surface.
- Comparison uses `resource.Quantity.Cmp()`, **not** naive string or struct equality -- `resource.Quantity` values with different internal representations (e.g. `1000m` vs `1`, or `1Gi` vs `1073741824`) can be numerically equal despite differing struct fields/formatted strings, so `Cmp()` is the only correct way to compare them.
- All-or-nothing per container, not per-resource-type. A container is either fully matched (all 4 values equal target) or not marked at all. This mirrors the dashboard's existing "Guaranteed QoS" table, which already compares requests and limits against `Target` for equality -- a container satisfying this is already sitting at the point recommendation.
- An unset request/limit is never treated as a match, even against a target of `0`, since "not set" and "explicitly set to this value" are different states (this mirrors the existing `GetStatus` helper's "not set" handling).

Implementation: `ContainerSummary.MatchesRecommendation() bool` in `pkg/summary/summary.go`, called directly from the `namespace.gohtml` template (`{{ if $cSummary.MatchesRecommendation }}`).

## Changes

- `pkg/summary/summary.go`: add `ContainerSummary.MatchesRecommendation()` and a small `quantityMatchesTarget` helper, using `resource.Quantity.Cmp()`.
- `pkg/summary/container_summary_test.go`: new table-driven unit tests covering exact match, equivalent-but-differently-represented quantities (e.g. `0.5` vs `500m`), single-value mismatch (CPU request only, memory limit only), fully unset, partially unset, and an unset value against a zero target.
- `pkg/dashboard/templates/namespace.gohtml`: render a `Matches Recommendation` badge next to the container name when `MatchesRecommendation()` is true.
- `pkg/dashboard/assets/css/main.css`: add a `.badge.--match` style using the existing `--color-positive` token (the same color already used for the "equals" success icon elsewhere), so it reads as consistent with the rest of the dashboard rather than a bolted-on element.

## Validation

- `go build ./...` succeeds.
- `go test ./...` -- all packages pass, including the new tests:
  ```
  ok  	github.com/fairwindsops/goldilocks/pkg/controller
  ok  	github.com/fairwindsops/goldilocks/pkg/dashboard/helpers
  ok  	github.com/fairwindsops/goldilocks/pkg/kube
  ok  	github.com/fairwindsops/goldilocks/pkg/summary
  ok  	github.com/fairwindsops/goldilocks/pkg/utils
  ok  	github.com/fairwindsops/goldilocks/pkg/vpa
  ```
- `go vet ./...` clean.
- `golangci-lint run ./...` -- 0 issues.
- Visual check: rendered the real `namespace`/`container` templates (with the actual CSS/fontawesome assets) against a fixture with one container whose requests/limits exactly match its VPA target and one that doesn't, and viewed the output in a browser. The badge appears only on the matching container, styled as a small teal pill consistent with the dashboard's other badges, with a check icon and no layout regressions in the rest of the container card.

## Test plan

- [x] Unit tests for `MatchesRecommendation` (match / no-match / partially-unset / fully-unset / equivalent-representation cases)
- [x] `go build`, `go test ./...`, `go vet ./...`, `golangci-lint run ./...`
- [x] Manual visual check of the rendered badge against real dashboard CSS