### PR TITLE
feat: support LimitRange defaults for current requests/limits

### DIFF
--- a/pkg/dashboard/assets/css/main.css
+++ b/pkg/dashboard/assets/css/main.css
@@ -366,6 +366,15 @@ COMPONENTS
   margin-left: var(--gap--1);
 }
 
+.badge.--limitrange {
+  align-items: center;
+  background: var(--color-warning);
+  color: var(--color-text-inverse-1);
+  display: inline-flex;
+  gap: var(--gap--2);
+  margin-left: var(--gap--1);
+}
+
 .detailInfo:not(.--qos) {
   --gap-detail: var(--gap-0);
 

--- a/pkg/dashboard/templates/container.gohtml
+++ b/pkg/dashboard/templates/container.gohtml
@@ -4,6 +4,11 @@
 {{ $memRequest := (index $.Requests (resourceName "memory")) }}
 {{ $memLimit := (index $.Limits (resourceName "memory")) }}
 
+{{ $cpuRequestFromLimitRange := (index $.RequestsFromLimitRange (resourceName "cpu")) }}
+{{ $cpuLimitFromLimitRange := (index $.LimitsFromLimitRange (resourceName "cpu")) }}
+{{ $memRequestFromLimitRange := (index $.RequestsFromLimitRange (resourceName "memory")) }}
+{{ $memLimitFromLimitRange := (index $.LimitsFromLimitRange (resourceName "memory")) }}
+
 {{ $cpuLowerBound := (index $.LowerBound (resourceName "cpu")) }}
 {{ $cpuUpperBound := (index $.UpperBound (resourceName "cpu")) }}
 {{ $memLowerBound := (index $.LowerBound (resourceName "memory")) }}
@@ -47,7 +52,7 @@
     <tbody>
       <tr>
         <th scope="row">CPU Request</th>
-        <td>{{ printResource $cpuRequest}}</td>
+        <td>{{ printResource $cpuRequest}}{{ template "limitRangeBadge" $cpuRequestFromLimitRange }}</td>
         <td>
           <i
             aria-hidden="true"
@@ -60,7 +65,7 @@
 
       <tr>
         <th scope="row">CPU Limit</th>
-        <td>{{ printResource $cpuLimit}}</td>
+        <td>{{ printResource $cpuLimit}}{{ template "limitRangeBadge" $cpuLimitFromLimitRange }}</td>
         <td>
           <i
             aria-hidden="true"
@@ -73,7 +78,7 @@
 
       <tr>
         <th scope="row">Memory Request</th>
-        <td>{{ printResource $memRequest}}</td>
+        <td>{{ printResource $memRequest}}{{ template "limitRangeBadge" $memRequestFromLimitRange }}</td>
         <td>
           <i
             aria-hidden="true"
@@ -86,7 +91,7 @@
 
       <tr>
         <th scope="row">Memory Limit</th>
-        <td>{{ printResource $memLimit}}</td>
+        <td>{{ printResource $memLimit}}{{ template "limitRangeBadge" $memLimitFromLimitRange }}</td>
         <td>
           <i
             aria-hidden="true"
@@ -141,7 +146,7 @@
     <tbody>
       <tr>
         <th scope="row">CPU Request</th>
-        <td>{{ printResource $cpuRequest}}</td>
+        <td>{{ printResource $cpuRequest}}{{ template "limitRangeBadge" $cpuRequestFromLimitRange }}</td>
         <td>
           <i
             aria-hidden="true"
@@ -154,7 +159,7 @@
 
       <tr>
         <th scope="row">CPU Limit</th>
-        <td>{{ printResource $cpuLimit}}</td>
+        <td>{{ printResource $cpuLimit}}{{ template "limitRangeBadge" $cpuLimitFromLimitRange }}</td>
         <td>
           <i
             aria-hidden="true"
@@ -167,7 +172,7 @@
 
       <tr>
         <th scope="row">Memory Request</th>
-        <td>{{ printResource $memRequest}}</td>
+        <td>{{ printResource $memRequest}}{{ template "limitRangeBadge" $memRequestFromLimitRange }}</td>
         <td>
           <i
             aria-hidden="true"
@@ -180,7 +185,7 @@
 
       <tr>
         <th scope="row">Memory Limit</th>
-        <td>{{ printResource $memLimit}}</td>
+        <td>{{ printResource $memLimit}}{{ template "limitRangeBadge" $memLimitFromLimitRange }}</td>
         <td>
           <i
             aria-hidden="true"
@@ -205,4 +210,13 @@
     memory: {{ printResource $memUpperBound }}</code></pre>
   </details>
 </section>
+{{ end }}
+
+{{ define "limitRangeBadge" }}
+{{ if . }}
+<span class="badge --limitrange" title="This value isn't set on the container itself; it's the effective value the container would get from the namespace's LimitRange default">
+  <i aria-hidden="true" class="fas fa-layer-group"></i>
+  From LimitRange
+</span>
+{{ end }}
 {{ end }}

--- a/pkg/summary/limitrange.go
+++ b/pkg/summary/limitrange.go
@@ -1,0 +1,156 @@
+// Copyright 2019 FairwindsOps Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package summary
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+)
+
+// containerLimitRangeItems returns every Container-typed LimitRangeItem found across all
+// LimitRange objects in the given namespace, in the order returned by the API. The result is
+// cached on the Summarizer for the remainder of its lifetime so that a namespace containing
+// many VPAs/workloads/containers only ever triggers a single LimitRanges List call, instead of
+// one per container.
+//
+// A namespace with no LimitRange objects (by far the common case) returns an empty, non-nil
+// slice and callers treat that as a no-op.
+func (s *Summarizer) containerLimitRangeItems(namespace string) []corev1.LimitRangeItem {
+	if s.limitRangeItemsByNamespace == nil {
+		s.limitRangeItemsByNamespace = map[string][]corev1.LimitRangeItem{}
+	}
+	if items, ok := s.limitRangeItemsByNamespace[namespace]; ok {
+		return items
+	}
+
+	items := []corev1.LimitRangeItem{}
+	limitRanges, err := s.kubeClient.Client.CoreV1().LimitRanges(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		// Don't fail the whole summary just because LimitRanges couldn't be listed (e.g. an
+		// RBAC restriction) -- fall back to behaving as if there were none, which is the same
+		// "Not Set" behavior this feature is layered on top of.
+		klog.Errorf("unable to list LimitRanges in namespace '%s', proceeding as if none exist: %v", namespace, err)
+	} else {
+		for _, lr := range limitRanges.Items {
+			for _, item := range lr.Spec.Limits {
+				// Only "Container" typed items apply to a specific container's requests/limits.
+				// "Pod" and "PersistentVolumeClaim" typed items constrain other things and are
+				// not relevant to what this dashboard displays.
+				if item.Type == corev1.LimitTypeContainer {
+					items = append(items, item)
+				}
+			}
+		}
+	}
+
+	s.limitRangeItemsByNamespace[namespace] = items
+	return items
+}
+
+// resolveEffectiveResources fills in the *effective* requests/limits a container would actually
+// receive from Kubernetes, given its own explicit resources.Requests/resources.Limits plus the
+// Container-typed LimitRangeItems that apply in its namespace. Values that are already explicit
+// on the container are always left untouched; a LimitRange only ever fills in a gap.
+//
+// The two maps returned indicate, per resource name (e.g. "cpu", "memory"), whether the
+// corresponding entry in the returned effRequests/effLimits was *not* present on the container
+// itself and was instead resolved from a namespace LimitRange.
+//
+// This intentionally reproduces two distinct steps of real Kubernetes behavior, in the same
+// order the API server performs them, because the order matters for a case that's easy to get
+// backwards:
+//
+//  1. Pod-level API defaulting (`SetDefaults_Pod` in k8s.io/kubernetes/pkg/apis/core/v1,
+//     https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/v1/defaults.go): if a
+//     container explicitly sets a Limit for a resource but leaves the Request unset, the Request
+//     is defaulted to equal that explicit Limit. This is pure type defaulting that runs at
+//     decode time, before any admission plugin (including LimitRanger) ever sees the object, and
+//     it only ever looks at what the container itself already specifies -- never at a value a
+//     LimitRange might go on to supply.
+//  2. LimitRanger admission (plugin/pkg/admission/limitranger): for any resource whose Limit is
+//     *still* unset after step 1, apply the namespace LimitRange's `Default`. For any resource
+//     whose Request is *still* unset after step 1, apply the namespace LimitRange's
+//     `DefaultRequest`. Because step 1 has already run, a Limit that only becomes set here (via
+//     `Default`) is never copied into a still-unset Request -- `DefaultRequest` is the only thing
+//     that can fill an unset Request at this stage. This is the trap: it's tempting to assume
+//     "Limit ends up set -> Request defaults to it" applies regardless of *how* the Limit was
+//     set, but Kubernetes' own ordering means that only holds for an explicit Limit.
+//
+// Multiple LimitRange objects (or multiple Container-typed items) in one namespace are also
+// possible. Per the Kubernetes docs (https://kubernetes.io/docs/concepts/policy/limit-range/,
+// "If two or more LimitRange objects exist in the namespace, it is not deterministic which
+// default value will be applied."), real admission behavior is explicitly non-deterministic
+// here. For display purposes we approximate LimitRanger's actual "only fill what's still
+// missing" mechanics (plugin/pkg/admission/limitranger/admission.go's mergeContainerResources)
+// applied across items in list order: the first applicable item found supplies a given resource,
+// later ones are ignored for that resource. limitRangeItems is expected to already be filtered
+// to Container-typed items (see containerLimitRangeItems), in the order they should be
+// considered.
+func resolveEffectiveResources(requests, limits corev1.ResourceList, limitRangeItems []corev1.LimitRangeItem) (effRequests, effLimits corev1.ResourceList, requestsFromLimitRange, limitsFromLimitRange map[corev1.ResourceName]bool) {
+	effRequests = requests.DeepCopy()
+	effLimits = limits.DeepCopy()
+	if effRequests == nil {
+		effRequests = corev1.ResourceList{}
+	}
+	if effLimits == nil {
+		effLimits = corev1.ResourceList{}
+	}
+
+	// Step 1: mimic SetDefaults_Pod -- an explicit Limit with no explicit Request becomes the
+	// Request. Deliberately iterates over the container's own original `limits`, not
+	// `effLimits`, so that a Limit added below by a LimitRange Default is never used as a
+	// source for this copy.
+	for name, explicitLimit := range limits {
+		if _, hasRequest := effRequests[name]; !hasRequest {
+			effRequests[name] = explicitLimit.DeepCopy()
+		}
+	}
+
+	// Step 2: apply namespace LimitRange defaults for anything still unset. First applicable
+	// item wins per resource name, independently for Default (limits) and DefaultRequest
+	// (requests).
+	for _, item := range limitRangeItems {
+		// Defense in depth: only "Container" typed items constrain a single container's
+		// requests/limits. Callers (containerLimitRangeItems) are expected to pre-filter to
+		// these, but a stray "Pod"/"PersistentVolumeClaim" typed item must never be applied
+		// here either.
+		if item.Type != corev1.LimitTypeContainer {
+			continue
+		}
+		for name, def := range item.Default {
+			if _, has := effLimits[name]; !has {
+				effLimits[name] = def.DeepCopy()
+				if limitsFromLimitRange == nil {
+					limitsFromLimitRange = map[corev1.ResourceName]bool{}
+				}
+				limitsFromLimitRange[name] = true
+			}
+		}
+		for name, def := range item.DefaultRequest {
+			if _, has := effRequests[name]; !has {
+				effRequests[name] = def.DeepCopy()
+				if requestsFromLimitRange == nil {
+					requestsFromLimitRange = map[corev1.ResourceName]bool{}
+				}
+				requestsFromLimitRange[name] = true
+			}
+		}
+	}
+
+	return effRequests, effLimits, requestsFromLimitRange, limitsFromLimitRange
+}

--- a/pkg/summary/limitrange_test.go
+++ b/pkg/summary/limitrange_test.go
@@ -1,0 +1,327 @@
+// Copyright 2019 FairwindsOps Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package summary
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/fairwindsops/goldilocks/pkg/kube"
+)
+
+func Test_resolveEffectiveResources(t *testing.T) {
+	containerItem := func(def, defReq corev1.ResourceList) corev1.LimitRangeItem {
+		return corev1.LimitRangeItem{
+			Type:           corev1.LimitTypeContainer,
+			Default:        def,
+			DefaultRequest: defReq,
+		}
+	}
+
+	tests := []struct {
+		name                       string
+		requests                   corev1.ResourceList
+		limits                     corev1.ResourceList
+		limitRangeItems            []corev1.LimitRangeItem
+		wantRequests               corev1.ResourceList
+		wantLimits                 corev1.ResourceList
+		wantRequestsFromLimitRange map[corev1.ResourceName]bool
+		wantLimitsFromLimitRange   map[corev1.ResourceName]bool
+	}{
+		{
+			name:            "no LimitRange in namespace is a no-op",
+			requests:        corev1.ResourceList{},
+			limits:          corev1.ResourceList{},
+			limitRangeItems: nil,
+			wantRequests:    corev1.ResourceList{},
+			wantLimits:      corev1.ResourceList{},
+		},
+		{
+			name:     "no LimitRange in namespace leaves explicit values untouched",
+			requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+			limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m")},
+			wantRequests: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("100m"),
+			},
+			wantLimits: corev1.ResourceList{
+				corev1.ResourceCPU: resource.MustParse("200m"),
+			},
+		},
+		{
+			name:     "only Default set: unset container fills in Limit but Request stays unset",
+			requests: corev1.ResourceList{},
+			limits:   corev1.ResourceList{},
+			limitRangeItems: []corev1.LimitRangeItem{
+				containerItem(corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")}, nil),
+			},
+			wantRequests: corev1.ResourceList{},
+			wantLimits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+			wantLimitsFromLimitRange: map[corev1.ResourceName]bool{corev1.ResourceMemory: true},
+		},
+		{
+			name:     "only DefaultRequest set: unset container fills in Request but Limit stays unset",
+			requests: corev1.ResourceList{},
+			limits:   corev1.ResourceList{},
+			limitRangeItems: []corev1.LimitRangeItem{
+				containerItem(nil, corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("256Mi")}),
+			},
+			wantRequests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+			wantLimits:                 corev1.ResourceList{},
+			wantRequestsFromLimitRange: map[corev1.ResourceName]bool{corev1.ResourceMemory: true},
+		},
+		{
+			name:     "both Default and DefaultRequest set on an unset container",
+			requests: corev1.ResourceList{},
+			limits:   corev1.ResourceList{},
+			limitRangeItems: []corev1.LimitRangeItem{
+				containerItem(
+					corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+					corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("256Mi")},
+				),
+			},
+			wantRequests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+			wantLimits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+			wantRequestsFromLimitRange: map[corev1.ResourceName]bool{corev1.ResourceMemory: true},
+			wantLimitsFromLimitRange:   map[corev1.ResourceName]bool{corev1.ResourceMemory: true},
+		},
+		{
+			// This is the trickiest edge case: a container that explicitly sets ONLY a Limit
+			// (no Request), in a namespace whose LimitRange has both Default and
+			// DefaultRequest. Real Kubernetes applies its "request defaults to explicit limit"
+			// Pod-level defaulting (SetDefaults_Pod) BEFORE LimitRanger ever runs, so the
+			// request becomes the container's own explicit limit value -- NOT the namespace's
+			// DefaultRequest. See https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/#if-you-specify-a-container-s-limit-but-not-its-request
+			name:     "explicit limit with no request ignores DefaultRequest and copies the explicit limit",
+			requests: corev1.ResourceList{},
+			limits:   corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")},
+			limitRangeItems: []corev1.LimitRangeItem{
+				containerItem(
+					corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+					corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("256Mi")},
+				),
+			},
+			wantRequests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			wantLimits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("1Gi"),
+			},
+			// Neither value came from the LimitRange: the limit is the container's own, and the
+			// request is copied from that explicit limit, not from DefaultRequest.
+		},
+		{
+			// Mirror sanity check: an explicit Request with no Limit picks up the namespace
+			// default Limit, and the explicit Request is never touched.
+			name:     "explicit request with no limit picks up Default for the limit only",
+			requests: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("128Mi")},
+			limits:   corev1.ResourceList{},
+			limitRangeItems: []corev1.LimitRangeItem{
+				containerItem(
+					corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+					corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("256Mi")},
+				),
+			},
+			wantRequests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("128Mi"),
+			},
+			wantLimits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+			wantLimitsFromLimitRange: map[corev1.ResourceName]bool{corev1.ResourceMemory: true},
+		},
+		{
+			name:     "a container with fully explicit values is never touched by LimitRange",
+			requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m"), corev1.ResourceMemory: resource.MustParse("128Mi")},
+			limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m"), corev1.ResourceMemory: resource.MustParse("256Mi")},
+			limitRangeItems: []corev1.LimitRangeItem{
+				containerItem(
+					corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1"), corev1.ResourceMemory: resource.MustParse("1Gi")},
+					corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m"), corev1.ResourceMemory: resource.MustParse("64Mi")},
+				),
+			},
+			wantRequests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m"), corev1.ResourceMemory: resource.MustParse("128Mi")},
+			wantLimits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m"), corev1.ResourceMemory: resource.MustParse("256Mi")},
+		},
+		{
+			name:     "cpu and memory are resolved independently",
+			requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")}, // memory request unset
+			limits:   corev1.ResourceList{},                                               // both limits unset
+			limitRangeItems: []corev1.LimitRangeItem{
+				containerItem(
+					corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1"), corev1.ResourceMemory: resource.MustParse("512Mi")},
+					corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("256Mi")}, // no cpu defaultRequest
+				),
+			},
+			wantRequests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"), // untouched, explicit
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+			wantLimits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("1"),
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+			wantRequestsFromLimitRange: map[corev1.ResourceName]bool{corev1.ResourceMemory: true},
+			wantLimitsFromLimitRange:   map[corev1.ResourceName]bool{corev1.ResourceCPU: true, corev1.ResourceMemory: true},
+		},
+		{
+			name:     "a Pod-typed LimitRangeItem is ignored, not applied to the container",
+			requests: corev1.ResourceList{},
+			limits:   corev1.ResourceList{},
+			limitRangeItems: []corev1.LimitRangeItem{
+				{
+					Type:    corev1.LimitTypePod,
+					Default: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+				},
+			},
+			wantRequests: corev1.ResourceList{},
+			wantLimits:   corev1.ResourceList{},
+		},
+		{
+			name:     "multiple LimitRange items: first applicable item wins per resource, gaps only filled",
+			requests: corev1.ResourceList{},
+			limits:   corev1.ResourceList{},
+			limitRangeItems: []corev1.LimitRangeItem{
+				containerItem(corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("256Mi")}, nil),
+				containerItem(corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")}, nil), // should be ignored for memory, already filled
+			},
+			wantLimits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("256Mi"),
+			},
+			wantRequests:             corev1.ResourceList{},
+			wantLimitsFromLimitRange: map[corev1.ResourceName]bool{corev1.ResourceMemory: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRequests, gotLimits, gotRequestsFromLimitRange, gotLimitsFromLimitRange := resolveEffectiveResources(tt.requests, tt.limits, tt.limitRangeItems)
+
+			assert.True(t, quantitiesEqual(tt.wantRequests, gotRequests), "requests: want %v got %v", tt.wantRequests, gotRequests)
+			assert.True(t, quantitiesEqual(tt.wantLimits, gotLimits), "limits: want %v got %v", tt.wantLimits, gotLimits)
+			assert.Equal(t, tt.wantRequestsFromLimitRange, gotRequestsFromLimitRange)
+			assert.Equal(t, tt.wantLimitsFromLimitRange, gotLimitsFromLimitRange)
+		})
+	}
+}
+
+// quantitiesEqual compares two ResourceLists by semantic quantity equality (via Cmp) rather than
+// struct equality, since resource.Quantity carries a private cached string representation that
+// can differ between two values constructed differently but representing the same amount.
+func quantitiesEqual(a, b corev1.ResourceList) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for name, qa := range a {
+		qb, ok := b[name]
+		if !ok || qa.Cmp(qb) != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func Test_Summarizer_containerLimitRangeItems(t *testing.T) {
+	t.Run("namespace with no LimitRange returns an empty, non-nil slice", func(t *testing.T) {
+		kubeClient := kube.GetMockClient()
+		s := &Summarizer{options: options{kubeClient: kubeClient}}
+
+		got := s.containerLimitRangeItems("empty-namespace")
+		assert.NotNil(t, got)
+		assert.Empty(t, got)
+	})
+
+	t.Run("only Container-typed items across possibly multiple LimitRange objects are returned", func(t *testing.T) {
+		kubeClient := kube.GetMockClient()
+		s := &Summarizer{options: options{kubeClient: kubeClient}}
+
+		_, err := kubeClient.Client.CoreV1().LimitRanges("testing").Create(context.TODO(), &corev1.LimitRange{
+			ObjectMeta: metav1.ObjectMeta{Name: "lr-a", Namespace: "testing"},
+			Spec: corev1.LimitRangeSpec{
+				Limits: []corev1.LimitRangeItem{
+					{
+						Type:    corev1.LimitTypePod,
+						Default: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("1Gi")},
+					},
+					{
+						Type:    corev1.LimitTypeContainer,
+						Default: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+					},
+				},
+			},
+		}, metav1.CreateOptions{})
+		assert.NoError(t, err)
+
+		_, err = kubeClient.Client.CoreV1().LimitRanges("testing").Create(context.TODO(), &corev1.LimitRange{
+			ObjectMeta: metav1.ObjectMeta{Name: "lr-b", Namespace: "testing"},
+			Spec: corev1.LimitRangeSpec{
+				Limits: []corev1.LimitRangeItem{
+					{
+						Type:           corev1.LimitTypeContainer,
+						DefaultRequest: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+					},
+				},
+			},
+		}, metav1.CreateOptions{})
+		assert.NoError(t, err)
+
+		got := s.containerLimitRangeItems("testing")
+		assert.Len(t, got, 2, "the Pod-typed item must be excluded")
+		for _, item := range got {
+			assert.Equal(t, corev1.LimitTypeContainer, item.Type)
+		}
+
+		// a different, unrelated namespace must not see these items
+		other := s.containerLimitRangeItems("other-namespace")
+		assert.Empty(t, other)
+	})
+
+	t.Run("result is cached so a second call for the same namespace doesn't hit the API again", func(t *testing.T) {
+		kubeClient := kube.GetMockClient()
+		s := &Summarizer{options: options{kubeClient: kubeClient}}
+
+		_, err := kubeClient.Client.CoreV1().LimitRanges("testing").Create(context.TODO(), &corev1.LimitRange{
+			ObjectMeta: metav1.ObjectMeta{Name: "lr-a", Namespace: "testing"},
+			Spec: corev1.LimitRangeSpec{
+				Limits: []corev1.LimitRangeItem{
+					{Type: corev1.LimitTypeContainer, Default: corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")}},
+				},
+			},
+		}, metav1.CreateOptions{})
+		assert.NoError(t, err)
+
+		first := s.containerLimitRangeItems("testing")
+		assert.Len(t, first, 1)
+
+		// delete the LimitRange from the fake API -- if containerLimitRangeItems were not
+		// caching, the second call would now see zero items
+		assert.NoError(t, kubeClient.Client.CoreV1().LimitRanges("testing").Delete(context.TODO(), "lr-a", metav1.DeleteOptions{}))
+
+		second := s.containerLimitRangeItems("testing")
+		assert.Len(t, second, 1, "expected cached result to be reused instead of re-querying the API")
+	})
+}

--- a/pkg/summary/summary.go
+++ b/pkg/summary/summary.go
@@ -59,12 +59,22 @@ type ContainerSummary struct {
 	ContainerName string `json:"containerName"`
 
 	// recommendations
-	LowerBound        corev1.ResourceList `json:"lowerBound"`
-	UpperBound        corev1.ResourceList `json:"upperBound"`
-	Target            corev1.ResourceList `json:"target"`
-	UncappedTarget    corev1.ResourceList `json:"uncappedTarget"`
-	Limits            corev1.ResourceList `json:"limits"`
-	Requests          corev1.ResourceList `json:"requests"`
+	LowerBound     corev1.ResourceList `json:"lowerBound"`
+	UpperBound     corev1.ResourceList `json:"upperBound"`
+	Target         corev1.ResourceList `json:"target"`
+	UncappedTarget corev1.ResourceList `json:"uncappedTarget"`
+	Limits         corev1.ResourceList `json:"limits"`
+	Requests       corev1.ResourceList `json:"requests"`
+
+	// RequestsFromLimitRange/LimitsFromLimitRange record, per resource name (e.g. "cpu",
+	// "memory"), whether the corresponding entry in Requests/Limits was not set explicitly on
+	// the container and was instead resolved from a namespace LimitRange (see
+	// resolveEffectiveResources in limitrange.go). A resource name absent from these maps was
+	// either set explicitly on the container, or is genuinely unset (no LimitRange applied
+	// either), and both of those still render as "Not Set" when the value itself is zero.
+	RequestsFromLimitRange map[corev1.ResourceName]bool `json:"requestsFromLimitRange,omitempty"`
+	LimitsFromLimitRange   map[corev1.ResourceName]bool `json:"limitsFromLimitRange,omitempty"`
+
 	BasePath          string
 	ContainerCost     float64
 	GuaranteedCost    float64
@@ -119,6 +129,10 @@ type Summarizer struct {
 
 	// cached map of vpa name -> workload
 	workloadForVPANamed map[string]*controllerUtils.Workload
+
+	// cached map of namespace -> Container-typed LimitRangeItems found in that namespace,
+	// populated lazily as the summary is built. See containerLimitRangeItems in limitrange.go.
+	limitRangeItemsByNamespace map[string][]corev1.LimitRangeItem
 }
 
 // NewSummarizer returns a Summarizer for all goldilocks managed VPAs in all Namespaces
@@ -257,14 +271,19 @@ func (s Summarizer) GetSummary() (Summary, error) {
 			for _, c := range workloadPodSpec.Containers {
 				// find the matching container on the workload
 				if c.Name == containerRecommendation.ContainerName {
+					limitRangeItems := s.containerLimitRangeItems(namespace)
+					effRequests, effLimits, requestsFromLimitRange, limitsFromLimitRange := resolveEffectiveResources(c.Resources.Requests, c.Resources.Limits, limitRangeItems)
+
 					cSummary = ContainerSummary{
-						ContainerName:  containerRecommendation.ContainerName,
-						UpperBound:     utils.FormatResourceList(containerRecommendation.UpperBound),
-						LowerBound:     utils.FormatResourceList(containerRecommendation.LowerBound),
-						Target:         utils.FormatResourceList(containerRecommendation.Target),
-						UncappedTarget: utils.FormatResourceList(containerRecommendation.UncappedTarget),
-						Limits:         utils.FormatResourceList(c.Resources.Limits),
-						Requests:       utils.FormatResourceList(c.Resources.Requests),
+						ContainerName:          containerRecommendation.ContainerName,
+						UpperBound:             utils.FormatResourceList(containerRecommendation.UpperBound),
+						LowerBound:             utils.FormatResourceList(containerRecommendation.LowerBound),
+						Target:                 utils.FormatResourceList(containerRecommendation.Target),
+						UncappedTarget:         utils.FormatResourceList(containerRecommendation.UncappedTarget),
+						Limits:                 utils.FormatResourceList(effLimits),
+						Requests:               utils.FormatResourceList(effRequests),
+						RequestsFromLimitRange: requestsFromLimitRange,
+						LimitsFromLimitRange:   limitsFromLimitRange,
 					}
 					klog.V(6).Infof("Resources for %s/%s/%s: Requests: %v Limits: %v", wSummary.ControllerType, wSummary.ControllerName, c.Name, cSummary.Requests, cSummary.Limits)
 					wSummary.Containers[cSummary.ContainerName] = cSummary

--- a/pkg/summary/summary_limitrange_test.go
+++ b/pkg/summary/summary_limitrange_test.go
@@ -1,0 +1,210 @@
+// Copyright 2019 FairwindsOps Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package summary
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	vpav1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+
+	"github.com/fairwindsops/goldilocks/pkg/kube"
+	"github.com/fairwindsops/goldilocks/pkg/utils"
+)
+
+// Test_Summarizer_LimitRange exercises the full GetSummary() pipeline (not just the
+// resolveEffectiveResources unit) for a workload whose container sets no resources of its own,
+// in a namespace that has a LimitRange with both Default (memory) and DefaultRequest (cpu) set.
+// This is the end-to-end version of issue #315: previously, this container would have shown
+// "Not Set" for every value; it should now show the values a real Pod created from this
+// workload would actually receive.
+func Test_Summarizer_LimitRange(t *testing.T) {
+	const namespace = "testing-limitrange"
+
+	kubeClientVPA := kube.GetMockVPAClient()
+	kubeClient := kube.GetMockClient()
+	dynamicClient := kube.GetMockDynamicClient()
+	controllerUtilsClient := kube.GetMockControllerUtilsClient(dynamicClient)
+
+	summarizer := NewSummarizer()
+	summarizer.kubeClient = kubeClient
+	summarizer.vpaClient = kubeClientVPA
+	summarizer.dynamicClient = dynamicClient
+	summarizer.controllerUtilsClient = controllerUtilsClient
+
+	// A namespace-wide LimitRange with Default memory (limit) and DefaultRequest cpu (request).
+	_, err := kubeClient.Client.CoreV1().LimitRanges(namespace).Create(context.TODO(), &corev1.LimitRange{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "limits",
+			Namespace: namespace,
+		},
+		Spec: corev1.LimitRangeSpec{
+			Limits: []corev1.LimitRangeItem{
+				{
+					Type: corev1.LimitTypeContainer,
+					Default: corev1.ResourceList{
+						corev1.ResourceMemory: resource.MustParse("512Mi"),
+					},
+					DefaultRequest: corev1.ResourceList{
+						corev1.ResourceCPU: resource.MustParse("100m"),
+					},
+				},
+			},
+		},
+	}, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	deployment := &unstructured.Unstructured{
+		Object: map[string]any{
+			"kind":       "Deployment",
+			"apiVersion": "apps/v1",
+			"metadata": map[string]any{
+				"name":      "test-limitrange-demo",
+				"namespace": namespace,
+			},
+			"spec": map[string]any{
+				"template": map[string]any{
+					"spec": map[string]any{
+						"containers": []any{
+							map[string]any{
+								"name": "container",
+								// no resources set at all -- everything should come from the
+								// namespace LimitRange (or remain "Not Set" for cpu limit,
+								// since the LimitRange has no Default for cpu).
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	replicaSet := &unstructured.Unstructured{
+		Object: map[string]any{
+			"kind":       "ReplicaSet",
+			"apiVersion": "apps/v1",
+			"metadata": map[string]any{
+				"ownerReferences": []any{
+					map[string]any{
+						"apiVersion": "apps/v1",
+						"kind":       "Deployment",
+						"controller": true,
+						"name":       "test-limitrange-demo",
+					},
+				},
+				"name":      "test-limitrange-demo-0123456789",
+				"namespace": namespace,
+			},
+			"spec": map[string]any{},
+		},
+	}
+	pod := &unstructured.Unstructured{
+		Object: map[string]any{
+			"kind":       "Pod",
+			"apiVersion": "v1",
+			"metadata": map[string]any{
+				"ownerReferences": []any{
+					map[string]any{
+						"apiVersion": "apps/v1",
+						"kind":       "ReplicaSet",
+						"controller": true,
+						"name":       "test-limitrange-demo-0123456789",
+					},
+				},
+				"name":      "test-limitrange-demo-0123456789-01234",
+				"namespace": namespace,
+			},
+			"spec": map[string]any{},
+		},
+	}
+
+	_, err = dynamicClient.Client.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}).Namespace(namespace).Create(context.TODO(), deployment, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	_, err = dynamicClient.Client.Resource(schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "replicasets"}).Namespace(namespace).Create(context.TODO(), replicaSet, metav1.CreateOptions{})
+	assert.NoError(t, err)
+	_, err = dynamicClient.Client.Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}).Namespace(namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	vpa := &vpav1.VerticalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "goldilocks-test-limitrange-demo",
+			Namespace: namespace,
+			Labels:    utils.VPALabels,
+		},
+		Spec: vpav1.VerticalPodAutoscalerSpec{
+			TargetRef: &autoscalingv1.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "test-limitrange-demo",
+			},
+			UpdatePolicy: &vpav1.PodUpdatePolicy{
+				UpdateMode: &updateMode,
+			},
+		},
+		Status: vpav1.VerticalPodAutoscalerStatus{
+			Recommendation: &vpav1.RecommendedPodResources{
+				ContainerRecommendations: []vpav1.RecommendedContainerResources{
+					{
+						ContainerName: "container",
+						Target:        targetResources,
+						UpperBound:    upperBound,
+						LowerBound:    lowerBound,
+					},
+				},
+			},
+		},
+	}
+	_, err = kubeClientVPA.Client.AutoscalingV1().VerticalPodAutoscalers(namespace).Create(context.TODO(), vpa, metav1.CreateOptions{})
+	assert.NoError(t, err)
+
+	got, err := summarizer.GetSummary()
+	assert.NoError(t, err)
+
+	nsSummary, ok := got.Namespaces[namespace]
+	assert.True(t, ok, "expected a summary for namespace %q", namespace)
+
+	wSummary, ok := nsSummary.Workloads["test-limitrange-demo"]
+	assert.True(t, ok, "expected a workload summary for test-limitrange-demo")
+
+	cSummary, ok := wSummary.Containers["container"]
+	assert.True(t, ok, "expected a container summary for 'container'")
+
+	// memory limit came from the LimitRange's Default
+	assert.True(t, quantitiesEqual(corev1.ResourceList{corev1.ResourceMemory: resource.MustParse("512Mi")},
+		corev1.ResourceList{corev1.ResourceMemory: cSummary.Limits[corev1.ResourceMemory]}))
+	assert.True(t, cSummary.LimitsFromLimitRange[corev1.ResourceMemory])
+
+	// cpu request came from the LimitRange's DefaultRequest
+	assert.True(t, quantitiesEqual(corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("100m")},
+		corev1.ResourceList{corev1.ResourceCPU: cSummary.Requests[corev1.ResourceCPU]}))
+	assert.True(t, cSummary.RequestsFromLimitRange[corev1.ResourceCPU])
+
+	// cpu limit has no Default in the LimitRange and no explicit value -- stays unset ("Not Set")
+	cpuLimit := cSummary.Limits[corev1.ResourceCPU]
+	assert.True(t, cpuLimit.IsZero())
+	assert.False(t, cSummary.LimitsFromLimitRange[corev1.ResourceCPU])
+
+	// memory request has no DefaultRequest and the container has no explicit memory limit
+	// either (so there's nothing to copy into the request) -- stays unset ("Not Set")
+	memRequest := cSummary.Requests[corev1.ResourceMemory]
+	assert.True(t, memRequest.IsZero())
+	assert.False(t, cSummary.RequestsFromLimitRange[corev1.ResourceMemory])
+}


### PR DESCRIPTION
## Problem

Closes #315.

When a container doesn't set its own `resources.requests`/`resources.limits`, but the namespace has a `LimitRange` that provides defaults, Goldilocks previously showed "Not Set" for those values -- even though a real Pod created from that workload would actually receive an effective value from Kubernetes. This made the "current" side of the dashboard misleading in namespaces that rely on `LimitRange` for baseline sizing.

## What changed

`Summarizer.GetSummary()` (`pkg/summary/summary.go`) now lists each namespace's `LimitRange` objects (via the existing `kube.ClientInstance`, the same client wrapper already used elsewhere) and resolves each container's *effective* requests/limits before building its `ContainerSummary`, instead of using the container's raw spec directly.

### Kubernetes semantics implemented, and why

This intentionally reproduces two separate, ordered steps that real Kubernetes performs, because the order changes the outcome for a case that's easy to get backwards:

1. **Pod-level API defaulting** (`SetDefaults_Pod`, [pkg/apis/core/v1/defaults.go](https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/v1/defaults.go)): if a container explicitly sets a Limit for a resource but leaves the Request unset, the Request is defaulted to that explicit Limit. This is decode-time type defaulting that runs **before any admission plugin** (including LimitRanger) ever sees the object, and it only ever looks at what the container itself already specifies.
2. **LimitRanger admission** (`plugin/pkg/admission/limitranger/admission.go`, `mergeContainerResources`): for any resource whose Limit is *still* unset after step 1, apply the LimitRange's `Default`. For any resource whose Request is *still* unset after step 1, apply `DefaultRequest`.

The consequence, verified against the [k8s LimitRange memory walkthrough](https://kubernetes.io/docs/tasks/administer-cluster/manage-resources/memory-default-namespace/) and the actual `SetDefaults_Pod`/`mergeContainerResources` source: **a Limit that only becomes set via step 2's `Default` is never copied into a still-unset Request.** Only an *explicit* Limit gets copied to Request (step 1); `DefaultRequest` is the only thing that can fill a Request left unset after step 1. It's tempting to assume "Limit ends up set -> Request defaults to it" applies regardless of how the Limit got set, but Kubernetes' ordering means that only holds for an explicit Limit. This is covered by a dedicated test case (see below).

Other rules implemented:
- Only `Container`-typed `LimitRangeItem`s apply to a container's own requests/limits; `Pod`/`PersistentVolumeClaim`-typed items are ignored.
- A container's own explicit values are never touched -- a LimitRange only ever fills a gap.
- cpu and memory (and in principle any resource name present in a `LimitRangeItem`) are resolved independently.
- A resource that's still unset after both steps continues to render as "Not Set" -- this feature only fills gaps Kubernetes itself would fill; it doesn't fabricate values.

**Design decision on multiple LimitRanges** (the one place where "correct" isn't fully pinned down): the [Kubernetes docs](https://kubernetes.io/docs/concepts/policy/limit-range/) state plainly that "If two or more LimitRange objects exist in the namespace, it is not deterministic which default value will be applied." For display purposes, this PR approximates LimitRanger's actual "only fill what's still missing" mechanics applied across items in List order: the first applicable item supplies a given resource, later ones are ignored for that resource once it's filled. This is a best-effort, deterministic approximation for the dashboard, not a guarantee of matching live-pod behavior in a namespace with conflicting multiple LimitRanges -- called out in code comments in `pkg/summary/limitrange.go`.

### Namespaces without a LimitRange (the common case)

`LimitRanges(namespace).List(...)` is called once per distinct namespace per summary generation (cached on the `Summarizer` for its lifetime), not once per container/workload/VPA, so this doesn't introduce an N+1. An empty list is a clean no-op -- verified requests/limits are byte-for-byte unchanged and the two existing full-summary regression tests (`Test_Summarizer`, `Test_Summarizer_Daemonset`) still pass unmodified against namespaces with no `LimitRange`.

### Dashboard

`ContainerSummary` gained `RequestsFromLimitRange`/`LimitsFromLimitRange` (`map[corev1.ResourceName]bool`), populated only when a value came from a LimitRange (nil otherwise, so existing JSON/API consumers see no change for the common no-`LimitRange` case). `pkg/dashboard/templates/container.gohtml` shows a small "From LimitRange" badge next to any such value, following the same visual pattern as the existing "Matches Recommendation" badge (`pkg/dashboard/templates/namespace.gohtml`) -- same badge CSS structure, just a different color (`--color-warning`) to keep it visually distinct.

## Validation performed

- `go build ./...` -- clean
- `go vet ./...` -- clean
- `gofmt -l` on all changed/added `.go` files -- no output
- `golangci-lint run ./...` (v2.12.0, locally installed; this repo has no checked-in `.golangci.yml` or lint CI workflow to pin a version against) -- `0 issues`
- `go test ./...` -- all packages pass, including the two new test files:
  - `pkg/summary/limitrange_test.go`: table-driven unit tests for the resolution function covering no-LimitRange no-op, only-`Default`, only-`DefaultRequest`, both set, explicit-values-untouched, cpu/memory resolved independently, Pod-typed items ignored, multiple LimitRange objects (first-applicable-wins), and the explicit-limit-copies-to-request-ignoring-DefaultRequest edge case described above. Also covers the namespace-level LimitRange listing/caching helper (empty namespace, filtering, and that repeated namespace lookups don't re-hit the fake API).
  - `pkg/summary/summary_limitrange_test.go`: a full `GetSummary()` integration test (fake clientsets, following this package's existing `kube.GetMockClient()`/`GetMockVPAClient()`/`GetMockDynamicClient()` conventions) with a container that sets no resources at all, verifying the end-to-end wiring.
- Manual sanity check: temporarily rendered the real `dashboard.Dashboard()` HTTP handler against fixture data (fake clientsets, a `LimitRange` with `Default` memory + `DefaultRequest` cpu, a container with no explicit resources) and inspected the output HTML. Confirmed: CPU Request = `100m` (badge shown), CPU Limit = `Not Set` (no badge, no `Default` configured), Memory Request = `Not Set` (no badge -- no `DefaultRequest` and nothing explicit to copy), Memory Limit = `512Mi` (badge shown). This throwaway test file was not committed.

## Notes

The issue's maintainer said he wasn't sure how hard this would be to implement correctly -- the main risk area was exactly the ordering edge case above (explicit-limit-only vs. Default-only vs. both), which I verified against the actual `SetDefaults_Pod`/LimitRanger source and the official walkthrough rather than assuming, since getting it backwards would make the feature actively misleading. The multi-LimitRange tie-break is the one place I made a judgment call rather than following a single documented "correct" behavior, since Kubernetes itself documents that case as non-deterministic.