### PR TITLE
test(vpa): add regression coverage for vpa-update-mode=InPlace (refs #862)

### DIFF
--- a/pkg/vpa/test_constants.go
+++ b/pkg/vpa/test_constants.go
@@ -98,6 +98,20 @@ var nsLabeledTrueUpdateModeAutoUnstructured = &unstructured.Unstructured{
 	},
 }
 
+var nsLabeledTrueUpdateModeInPlace corev1.Namespace
+var nsLabeledTrueUpdateModeInPlaceUnstructured = &unstructured.Unstructured{
+	Object: map[string]any{
+		"kind": "Namespace",
+		"metadata": map[string]any{
+			"name": "labeled-true",
+			"labels": map[string]any{
+				"goldilocks.fairwinds.com/enabled":         "True",
+				"goldilocks.fairwinds.com/vpa-update-mode": "InPlace",
+			},
+		},
+	},
+}
+
 var nsLabeledResourcePolicy corev1.Namespace
 var nsLabeledResourcePolicyUnstructured = &unstructured.Unstructured{
 	Object: map[string]any{

--- a/pkg/vpa/vpa_test.go
+++ b/pkg/vpa/vpa_test.go
@@ -53,6 +53,8 @@ func setupVPAForTests(t *testing.T) {
 	assert.NoError(t, err)
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(nsLabeledTrueUpdateModeAutoUnstructured.Object, &nsLabeledTrueUpdateModeAuto)
 	assert.NoError(t, err)
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(nsLabeledTrueUpdateModeInPlaceUnstructured.Object, &nsLabeledTrueUpdateModeInPlace)
+	assert.NoError(t, err)
 	err = runtime.DefaultUnstructuredConverter.FromUnstructured(nsLabeledResourcePolicyUnstructured.Object, &nsLabeledResourcePolicy)
 	assert.NoError(t, err)
 }
@@ -95,6 +97,12 @@ func Test_vpaUpdateModeForNamespace(t *testing.T) {
 			ns:         &nsLabeledTrueUpdateModeAuto,
 			explicit:   true,
 			updateMode: vpav1.UpdateModeRecreate,
+		},
+		{
+			name:       "labled: enabled=true, vpa-update-mode=InPlace",
+			ns:         &nsLabeledTrueUpdateModeInPlace,
+			explicit:   true,
+			updateMode: vpav1.UpdateModeInPlace,
 		},
 	}
 


### PR DESCRIPTION
## Summary

Refs #862.

#862 reported that the `goldilocks.fairwinds.com/vpa-update-mode=InPlace` annotation caused the VPA admission webhook to reject the object with `Unsupported value: "Inplace"` — a naive `ToUpper(str[0:1]) + ToLower(str[1:])` normalization mangling `InPlace` into `Inplace`.

Digging in, that specific bug looks already fixed on `master`, via two separate commits that landed after the issue was reported:
- #781 replaced the naive re-casing with case-insensitive matching against a fixed `allowedUpdateModes` list.
- `de70ae1` (#879) added `vpav1.UpdateModeInPlace` to that list (previously only `InPlaceOrRecreate` was present, so `InPlace` alone still fell through to the default `Off` even after #781).

Neither of those commits added a test for this exact case, so I couldn't find explicit confirmation the reported scenario was covered. I added a regression test reproducing the issue's exact annotation value (`vpa-update-mode=InPlace`) and confirmed it now correctly resolves to `vpav1.UpdateModeInPlace`.

## Test plan

- Added `nsLabeledTrueUpdateModeInPlace` fixture and a new case in `Test_vpaUpdateModeForNamespace` asserting `vpa-update-mode=InPlace` resolves to `vpav1.UpdateModeInPlace` with `explicit=true`.
- `go test ./...` — all packages pass.

No production code changes — this is test-only, since the underlying bug appears already resolved. If confirmed, #862 can probably be closed.