### PR TITLE
test(vpa): guard camel-cased update mode through the reconcile path (closes #862)

### DIFF
--- a/pkg/vpa/vpa_test.go
+++ b/pkg/vpa/vpa_test.go
@@ -662,6 +662,18 @@ func Test_ReconcileNamespace_ChangeUpdateMode(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(vpaList1.Items))
 	assert.EqualValues(t, *vpaList1.Items[0].Spec.UpdatePolicy.UpdateMode, vpav1.UpdateModeRecreate)
+
+	// A camel-cased mode must reach the VPA spec with the exact casing the VPA
+	// API expects ("InPlace"), not a mangled value such as "Inplace".
+	_, err = DynamicClient.Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}).Update(context.TODO(), nsLabeledTrueUpdateModeInPlaceUnstructured, metav1.UpdateOptions{})
+	assert.NoError(t, err)
+	err = GetInstance().ReconcileNamespace(&nsLabeledTrueUpdateModeInPlace)
+	assert.NoError(t, err)
+
+	vpaList2, err := VPAClient.Client.AutoscalingV1().VerticalPodAutoscalers(nsName).List(context.TODO(), metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(vpaList2.Items))
+	assert.EqualValues(t, *vpaList2.Items[0].Spec.UpdatePolicy.UpdateMode, vpav1.UpdateModeInPlace)
 }
 
 func Test_ReconcileNamespaceDaemonset(t *testing.T) {


### PR DESCRIPTION
## Checklist

* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description

### What's the goal of this PR?

Close out #862 (and its duplicate #873) by adding a regression guard at the layer where that bug actually surfaced.

### Background

#862 reported that `goldilocks.fairwinds.com/vpa-update-mode=InPlace` produced:

```
admission webhook "vpa.k8s.io" denied the request: ... spec.updatePolicy.updateMode: Unsupported value: "Inplace": supported values: "InPlace", "InPlaceOrRecreate", "Initial", "Off", "Recreate"
```

Tracing the history:

- Before #781, `vpaUpdateModeForResource` did `strings.ToUpper(s[:1]) + strings.ToLower(s[1:])`, so `InPlace` → `Inplace` and any camel-cased mode was mangled.
- #781 replaced that with a match against `allowedUpdateModes`, returning the typed constant — but the list did not yet include `vpav1.UpdateModeInPlace`, so `InPlace` fell through to the `Off` default.
- #879 (VPA library bump to v1.7.0) added `vpav1.UpdateModeInPlace` to `allowedUpdateModes`, which is what actually fixes the reported error on current `main`.
- #883 added parser-level coverage in `Test_vpaUpdateModeForNamespace`.

So the bug is already resolved as of the current release line. The remaining gap is test coverage at the reconcile/emission layer: `Test_ReconcileNamespace_ChangeUpdateMode` only exercised the legacy `auto` alias, which resolves to the single-word mode `Recreate` and would not have caught the casing mangle.

### What changes did you make?

Extended `Test_ReconcileNamespace_ChangeUpdateMode` to also switch the namespace to `InPlace`, reconcile, and assert the emitted VPA's `spec.updatePolicy.updateMode` is exactly `InPlace`. Verified the assertion fails (mode falls back to `Off`) if `vpav1.UpdateModeInPlace` is removed from `allowedUpdateModes`.

### What alternative solution should we consider, if any?

None — test-only change.